### PR TITLE
Release IBF 0.8.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ authors:
   - family-names: Gordon
     given-names: Neil
     orcid: "https://orcid.org/0000-0002-7664-9434"
-version: "0.8.0"
-date-released: "2026-07-26"
+version: "0.8.1"
+date-released: "2026-07-28"
 repository-code: "https://github.com/tehoro/ibf"
 url: "https://github.com/tehoro/ibf"
 license: Apache-2.0
@@ -35,6 +35,6 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-7664-9434"
   title: "IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts"
   year: 2026
-  version: "0.8.0"
+  version: "0.8.1"
   url: "https://github.com/tehoro/ibf"
   license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -422,10 +422,16 @@ downloaded models as well as the models already held in memory.
 
 LM Studio's loaded context length must accommodate the complete system and user prompts plus the
 requested output allowance. Area prompts can be much larger than location prompts because they
-combine representative locations and ensemble scenarios. IBF logs the character/byte size, a
-rough input-token estimate, and the requested maximum output tokens before every LLM call. If LM
+combine representative locations and ensemble scenarios, but long spot forecasts with many
+retained ensemble members can also exceed a model's limit. IBF logs the character/byte size, a
+rough input-token estimate, the requested maximum output tokens, and their estimated combined
+context requirement before every LLM call. If LM
 Studio rejects a prompt for exceeding its context window, IBF identifies that cause explicitly and
-immediately tries `llm_fallback` when configured.
+immediately tries `llm_fallback` when configured. If an area or regional forecast still fails with
+an explicit context-size error, IBF rebuilds the prompt from the already downloaded data with half
+as many representative ensemble scenarios and retries, progressively reducing to one scenario only
+if necessary. The same recovery applies to ensemble spot forecasts. Deterministic forecasts and
+other LLM failures do not trigger scenario reduction.
 
 Useful LM Studio references:
 
@@ -714,9 +720,12 @@ Troubleshooting (technical)
 - LM Studio connection errors: start its API server, verify `lm_studio_base_url`, local-network and
   firewall settings, and authentication. The error lists the model identifiers visible from
   `/v1/models`; the configured `lms:` identifier must match exactly.
-- LM Studio context-length errors: increase the model's loaded context length, reduce forecast
-  days, representative locations, or `area_thin_select`, or configure a larger-context cloud model
-  as `llm_fallback`. Check the logged prompt-size estimate before choosing a context length.
+- LM Studio context-length errors: IBF automatically retries ensemble location, area and regional
+  forecasts with fewer representative scenarios when the server explicitly reports context
+  overflow. You can also increase the model's loaded context length, reduce forecast days or
+  representative locations, lower `location_thin_select` or `area_thin_select`, or configure a
+  larger-context cloud model as `llm_fallback`. The logged token count is an estimate because
+  OpenAI-compatible local servers do not expose a universal tokenizer.
 - Experimental Brave context errors: confirm `BRAVE_SEARCH_API_KEY`, subscription to Brave's Search plan, and
   network connectivity. Brave requires a new key to be generated for a new subscription. IBF logs
   Brave's structured error code and message. Configure `context_fallback_llm` only if you want the

--- a/README.md
+++ b/README.md
@@ -747,4 +747,4 @@ If you use IBF in research, software, or documentation, please cite it using the
 
 A suggested citation (from `CITATION.cff`) is:
 
-> Gordon, Neil. *IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts* (v0.8.0). 2026. [https://github.com/tehoro/ibf](https://github.com/tehoro/ibf)
+> Gordon, Neil. *IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts* (v0.8.1). 2026. [https://github.com/tehoro/ibf](https://github.com/tehoro/ibf)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Impact context note:
 - If impact context cannot be obtained, IBF loudly logs the failure and continues without that
   extra context. Configure `context_fallback_llm` only if an experimental Brave run should try the
   recommended hosted-search method once.
+- Generated forecast pages identify the language model that actually wrote the forecast and, when
+  applicable, the model that produced the translation. The expanded impact-context panel also
+  records its research provider, model, and generation time; this metadata is retained when context
+  is reused from cache.
 
 Recommended LLM choices
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibf"
-version = "0.8.0"
+version = "0.8.1"
 description = "Unified impact-based forecast CLI and service"
 readme = "README.md"
 authors = [

--- a/src/ibf/api/impact.py
+++ b/src/ibf/api/impact.py
@@ -58,12 +58,18 @@ class ImpactContext:
         content: The generated context text.
         from_cache: True if the content was loaded from disk cache.
         cache_path: Path to the cache file (if applicable).
+        provider: Research provider that produced the context.
+        model: Model that produced or synthesised the context.
+        generated_at: ISO timestamp recording when the context was generated.
     """
     name: str
     content: str
     from_cache: bool
     cache_path: Optional[Path] = None
     cost_cents: float = 0.0
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    generated_at: Optional[str] = None
 
 
 def fetch_impact_context(
@@ -128,6 +134,11 @@ def fetch_impact_context(
         max_age_days=max_age_days,
     )
     if cached_context:
+        cached_provider, cached_model, cached_generated_at = _load_context_provenance(
+            cache_path,
+            default_provider=context_provider,
+            default_model=context_llm,
+        )
         cached_local_date = get_local_now(timezone_name).date()
         cached_context, removed_events = _filter_invalid_upcoming_event_bullets(
             cached_context,
@@ -149,8 +160,13 @@ def fetch_impact_context(
             from_cache=True,
             cache_path=cache_path,
             cost_cents=0.0,
+            provider=cached_provider,
+            model=cached_model,
+            generated_at=cached_generated_at,
         )
 
+    source_provider = context_provider
+    source_model = context_llm
     if context_provider == "brave":
         try:
             context, cost_cents = _generate_context_brave(
@@ -188,6 +204,8 @@ def fetch_impact_context(
                     representative_locations=normalized_locations,
                 )
                 cost_cents = brave_cost_cents + fallback_cost_cents
+                source_provider = "llm-search"
+                source_model = context_fallback_llm
             else:
                 context, cost_cents = "", brave_cost_cents
     else:
@@ -202,6 +220,7 @@ def fetch_impact_context(
             representative_locations=normalized_locations,
         )
     if context:
+        generated_at = get_local_now(timezone_name).isoformat()
         store_impact_context(
             name,
             context,
@@ -210,6 +229,9 @@ def fetch_impact_context(
             timezone_name=timezone_name,
             context_llm=cache_identity,
             extra_context=extra_context,
+            source_provider=source_provider,
+            source_model=source_model,
+            generated_at=generated_at,
         )
         return ImpactContext(
             name=name,
@@ -217,6 +239,9 @@ def fetch_impact_context(
             from_cache=False,
             cache_path=cache_path,
             cost_cents=cost_cents,
+            provider=source_provider,
+            model=source_model,
+            generated_at=generated_at,
         )
 
     logger.info("Impact context unavailable for %s (%s); continuing without it.", name, context_type)
@@ -238,6 +263,9 @@ def store_impact_context(
     timezone_name: str = "UTC",
     context_llm: str = DEFAULT_CONTEXT_LLM,
     extra_context: Optional[str] = None,
+    source_provider: Optional[str] = None,
+    source_model: Optional[str] = None,
+    generated_at: Optional[str] = None,
 ) -> None:
     """
     Save generated impact context to the filesystem cache.
@@ -259,14 +287,17 @@ def store_impact_context(
         context_llm=context_llm,
         extra_context=extra_context,
     )
+    timestamp = generated_at or get_local_now(timezone_name).isoformat()
     payload = {
         "context": content,
-        "timestamp": get_local_now(timezone_name).isoformat(),
+        "timestamp": timestamp,
         "context_type": context_type,
         "name": name,
         "forecast_days": forecast_days,
         "context_llm": context_llm,
         "extra_context": extra_context,
+        "source_provider": source_provider,
+        "source_model": source_model,
     }
     try:
         write_text_file(cache_path, json.dumps(payload, indent=2, ensure_ascii=False))
@@ -364,6 +395,27 @@ def _load_cache(path: Path, *, max_age_days: int = MAX_CONTEXT_AGE_DAYS) -> Opti
     if now_utc - cached_ts.astimezone(timezone.utc) > timedelta(days=max_age_days):
         return None
     return data.get("context", "")
+
+
+def _load_context_provenance(
+    path: Optional[Path],
+    *,
+    default_provider: str,
+    default_model: str,
+) -> tuple[str, str, Optional[str]]:
+    """Read provenance from a context cache, retaining compatibility with older files."""
+    if path is None:
+        return default_provider, default_model, None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return default_provider, default_model, None
+    if not isinstance(data, dict):
+        return default_provider, default_model, None
+    provider = str(data.get("source_provider") or default_provider).strip()
+    model = str(data.get("source_model") or default_model).strip()
+    generated_at = data.get("timestamp")
+    return provider, model, str(generated_at) if generated_at else None
 
 
 def _delete_cache_file(path: Path) -> None:

--- a/src/ibf/llm/formatter.py
+++ b/src/ibf/llm/formatter.py
@@ -707,6 +707,11 @@ def precipitation_or_snowfall_likely(label: str, values: List[float], unit: str)
 
     lower_text = _fmt(lower)
     upper_text = _fmt(upper)
+    if lower <= 0:
+        return (
+            f"Estimated probability of {label}: {probability}%\n"
+            f"Likely {label} up to {upper_text} {unit_label}"
+        )
     if lower == upper:
         return f"Estimated probability of {label}: {probability}%\nLikely {label} around {lower_text} {unit_label}"
     return f"Estimated probability of {label}: {probability}%\nLikely {label} {lower_text} {unit_label} to {upper_text} {unit_label}"

--- a/src/ibf/llm/formatter.py
+++ b/src/ibf/llm/formatter.py
@@ -693,6 +693,12 @@ def precipitation_or_snowfall_likely(label: str, values: List[float], unit: str)
     lower = round(percentiles[0], precision)
     upper = round(percentiles[1], precision)
 
+    # Preserve the probability signal for trace amounts, but do not give the
+    # forecast writer a meaningless amount such as "around 0 mm".  The hourly
+    # data can still be used to describe the timing and type of precipitation.
+    if upper <= 0:
+        return f"Estimated probability of {label}: {probability}%"
+
     def _fmt(value: float) -> str:
         """Format values with the desired decimal precision."""
         if precision == 0:

--- a/src/ibf/llm/prompts.py
+++ b/src/ibf/llm/prompts.py
@@ -71,7 +71,7 @@ Describe the most likely conditions and also mention important alternative outco
 - ALWAYS refer to temperatures as **low** and **high**; never use the plural words "highs" or "lows".
 - When a low/high range is provided in the RANGE SUMMARY, ALWAYS include both endpoints in the forecast (e.g., "low 15 to 18°C"); do not collapse to a single value.
 - When reporting temperature ranges, repeat the unit after both endpoints (e.g., "-1°C to 10°C").
-- When a rainfall or snowfall range starts at 0 (or rounds to 0), express it as "up to X [unit]" in the narrative rather than "0 to X [unit]".
+- When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
 - When reporting snowfall in inches, round to the nearest whole inch in the narrative; if the range stays below 1 inch, say "less than 1 inch".
 
@@ -183,7 +183,7 @@ You will receive forecast datasets for several locations inside the target area.
 #STYLE & CONTENT
 - Use simple, clear language that a 12-year-old could understand.
 - Mention precipitation timing and type when wet weather is expected, plus the likely range of amounts when the data explicitly provides one.
-- When a rainfall or snowfall range starts at 0 (or rounds to 0), express it as "up to X [unit]" in the narrative rather than "0 to X [unit]".
+- When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
 - When reporting snowfall in inches, round to the nearest whole inch in the narrative; if the range stays below 1 inch, say "less than 1 inch".
 - Always describe at least one wind direction and speed range using the required unit, and spell out the direction (e.g., "southwesterlies") instead of abbreviations.
@@ -238,7 +238,7 @@ You will receive forecast datasets for several locations inside the target area.
 #STYLE & CONTENT
 - Use simple, clear language that a 12-year-old could understand.
 - Mention precipitation timing and type when wet weather is expected, plus amounts when the data explicitly provides them.
-- When a rainfall or snowfall range starts at 0 (or rounds to 0), express it as "up to X [unit]" in the narrative rather than "0 to X [unit]".
+- When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
 - When reporting snowfall in inches, round to the nearest whole inch in the narrative; if the range stays below 1 inch, say "less than 1 inch".
 - Always describe at least one wind direction and speed range using the required unit, and spell out the direction (e.g., "southwesterlies") instead of abbreviations.
@@ -285,7 +285,7 @@ You are an expert regional meteorologist. Use the supplied representative locati
 - For ensemble ranges, always include both endpoints for low/high temperatures (e.g., "low 15 to 18°C"); do not collapse to a single value.
 - When reporting temperature ranges, repeat the unit after both endpoints (e.g., "-1°C to 10°C").
 - Vary the wording of the low/high temperature sentence across days; for ranges, keep both endpoints while varying phrasing.
-- When a rainfall or snowfall range starts at 0 (or rounds to 0), express it as "up to X [unit]" in the narrative rather than "0 to X [unit]".
+- When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
 - When reporting snowfall in inches, round to the nearest whole inch in the narrative; if the range stays below 1 inch, say "less than 1 inch".
 - If the datasets include snow-level notes (e.g., "(snow down to about 6500 ft)"), include them. Describe snow on higher terrain/mountains/hills above that elevation and avoid implying widespread lowland snow when levels are high.
@@ -326,7 +326,7 @@ You are an expert regional meteorologist. Use the supplied representative locati
 - After the day header, write one paragraph per sub-region. Begin each paragraph with the bolded region name followed by a colon (e.g., "**South West England:** ...").
 - Describe weather, wind (with speed range), precipitation timing and any explicitly provided amounts, and temperature low/high for each region using the required units.
 - Vary the wording of the low/high temperature sentence across days while still stating a single low and a single high from the data.
-- When a rainfall or snowfall range starts at 0 (or rounds to 0), express it as "up to X [unit]" in the narrative rather than "0 to X [unit]".
+- When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
 - When reporting snowfall in inches, round to the nearest whole inch in the narrative; if the range stays below 1 inch, say "less than 1 inch".
 - If the datasets include snow-level notes (e.g., "(snow down to about 6500 ft)"), include them. Describe snow on higher terrain/mountains/hills above that elevation and avoid implying widespread lowland snow when levels are high.

--- a/src/ibf/llm/prompts.py
+++ b/src/ibf/llm/prompts.py
@@ -56,7 +56,8 @@ Always refer to the date and specific day of the week exactly as mentioned in th
 
 #TIMING LANGUAGE
 - Do NOT use specific clock times like "2:00 pm", "10:00 am", or "14:00".
-- Express timing using broad parts of the day instead: early morning, mid-morning, late morning, around midday, early afternoon, mid-afternoon, late afternoon, early evening, evening, late evening, overnight, towards dawn.
+- Express timing using broad parts of the day instead: early morning, mid-morning, late morning, around midday, early afternoon, mid-afternoon, late afternoon, early evening, evening, and late evening.
+- Do not use "overnight" as a forecast timing label. Hours from midnight through before sunrise belong to that named day's early morning; hours before midnight at the end of the preceding day are late evening. Preserve the word only when it occurs in official alert wording that must be reproduced exactly.
 - If you need to describe a narrow window, do it approximately without clock times (e.g., "for a couple of hours in mid-afternoon").
 - Exception: If an official alert includes exact clock times, reproduce those times verbatim (and attribute them to the alert).
 
@@ -77,11 +78,11 @@ Describe the most likely conditions and also mention important alternative outco
 
 #FORMAT FOR A DAY
 - Each day must start with the bolded header followed by the forecast in the same paragraph.
-- Include weather conditions, timing of any precipitation (morning/afternoon/evening/night), at least one wind direction with speed, and both the low and high temperatures using the specified units.
+- Include weather conditions, timing of any precipitation (morning/afternoon/evening), at least one wind direction with speed, and both the low and high temperatures using the specified units.
 - Vary the wording of the low/high temperature sentence across days; for ranges, keep both endpoints from the RANGE SUMMARY while varying phrasing.
 - Use future tense for temperatures ("the low will be...", "the high is expected near...").
 - For partial days (e.g., "Rest of Today"), describe only the remaining part of the day and keep it very brief if only 1–2 hours remain.
-- When very little of the day remains (for example "Rest of Today" issued late afternoon/evening), describe how temperatures will trend (e.g., "temperatures fall from 18°C early evening to about 13°C overnight") instead of quoting a formal low/high pair.
+- When very little of the day remains (for example "Rest of Today" issued late afternoon/evening), describe how temperatures will trend without adding unnecessary timing labels (e.g., "temperatures will fall from 18°C to about 13°C") instead of quoting a formal low/high pair.
 
 #ALERTS
 - If any alerts are provided, explicitly work each one into the relevant day's paragraph. State the official source exactly as provided (e.g., MetService) along with the alert title and hazard.
@@ -125,7 +126,8 @@ Always refer to the date and specific day of the week exactly as mentioned in th
 
 #TIMING LANGUAGE
 - Do NOT use specific clock times like "2:00 pm", "10:00 am", or "14:00".
-- Express timing using broad parts of the day instead: early morning, mid-morning, late morning, around midday, early afternoon, mid-afternoon, late afternoon, early evening, evening, late evening, overnight, towards dawn.
+- Express timing using broad parts of the day instead: early morning, mid-morning, late morning, around midday, early afternoon, mid-afternoon, late afternoon, early evening, evening, and late evening.
+- Do not use "overnight" as a forecast timing label. Hours from midnight through before sunrise belong to that named day's early morning; hours before midnight at the end of the preceding day are late evening. Preserve the word only when it occurs in official alert wording that must be reproduced exactly.
 - If you need to describe a narrow window, do it approximately without clock times (e.g., "for a couple of hours in mid-afternoon").
 - Exception: If an official alert includes exact clock times, reproduce those times verbatim (and attribute them to the alert).
 
@@ -143,11 +145,11 @@ Describe expected conditions using the provided data. Do not imply spatial varia
 
 #FORMAT FOR A DAY
 - Each day must start with the bolded header followed by the forecast in the same paragraph.
-- Include weather conditions, timing of any precipitation (morning/afternoon/evening/night), at least one wind direction with speed, and both the low and high temperatures using the specified units.
+- Include weather conditions, timing of any precipitation (morning/afternoon/evening), at least one wind direction with speed, and both the low and high temperatures using the specified units.
 - Vary the wording of the low/high temperature sentence across days while still stating a single low and a single high from the data.
 - Use future tense for temperatures ("the low will be...", "the high is expected near...").
 - For partial days (e.g., "Rest of Today"), describe only the remaining part of the day and keep it very brief if only 1–2 hours remain.
-- When very little of the day remains (for example "Rest of Today" issued late afternoon/evening), describe how temperatures will trend (e.g., "temperatures fall from 18°C early evening to about 13°C overnight") instead of quoting a formal low/high pair.
+- When very little of the day remains (for example "Rest of Today" issued late afternoon/evening), describe how temperatures will trend without adding unnecessary timing labels (e.g., "temperatures will fall from 18°C to about 13°C") instead of quoting a formal low/high pair.
 
 #ALERTS
 - If any alerts are provided, explicitly work each one into the relevant day's paragraph. State the official source exactly as provided (e.g., MetService) along with the alert title and hazard.
@@ -203,7 +205,8 @@ You will receive forecast datasets for several locations inside the target area.
 
 #TIMING LANGUAGE
 - Do NOT use specific clock times like "2:00 pm", "10:00 am", or "14:00".
-- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday; overnight; towards dawn).
+- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday).
+- Do not use "overnight" as a forecast timing label. Hours from midnight through before sunrise belong to that named day's early morning; hours before midnight at the end of the preceding day are late evening. Preserve the word only when it occurs in official alert wording that must be reproduced exactly.
 - If you need to describe a narrow window, do it approximately without clock times (e.g., "for a couple of hours in mid-afternoon").
 - Exception: If you are quoting or paraphrasing official alert timing that includes exact clock times, reproduce those times verbatim (and make clear they come from the alert).
 
@@ -255,7 +258,8 @@ You will receive forecast datasets for several locations inside the target area.
 
 #TIMING LANGUAGE
 - Do NOT use specific clock times like "2:00 pm", "10:00 am", or "14:00".
-- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday; overnight; towards dawn).
+- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday).
+- Do not use "overnight" as a forecast timing label. Hours from midnight through before sunrise belong to that named day's early morning; hours before midnight at the end of the preceding day are late evening. Preserve the word only when it occurs in official alert wording that must be reproduced exactly.
 - If you need to describe a narrow window, do it approximately without clock times (e.g., "for a couple of hours in mid-afternoon").
 - Exception: If you are quoting or paraphrasing official alert timing that includes exact clock times, reproduce those times verbatim (and make clear they come from the alert).
 
@@ -299,7 +303,8 @@ You are an expert regional meteorologist. Use the supplied representative locati
 
 #TIMING LANGUAGE
 - Do NOT use specific clock times like "2:00 pm", "10:00 am", or "14:00".
-- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday; overnight; towards dawn).
+- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday).
+- Do not use "overnight" as a forecast timing label. Hours from midnight through before sunrise belong to that named day's early morning; hours before midnight at the end of the preceding day are late evening. Preserve the word only when it occurs in official alert wording that must be reproduced exactly.
 - If you need to describe a narrow window, do it approximately without clock times (e.g., "for a couple of hours in mid-afternoon").
 - Exception: If you are quoting or paraphrasing official alert timing that includes exact clock times, reproduce those times verbatim (and make clear they come from the alert).
 
@@ -339,7 +344,8 @@ You are an expert regional meteorologist. Use the supplied representative locati
 
 #TIMING LANGUAGE
 - Do NOT use specific clock times like "2:00 pm", "10:00 am", or "14:00".
-- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday; overnight; towards dawn).
+- Prefer broad timing phrases (early/mid/late morning/afternoon/evening; around midday).
+- Do not use "overnight" as a forecast timing label. Hours from midnight through before sunrise belong to that named day's early morning; hours before midnight at the end of the preceding day are late evening. Preserve the word only when it occurs in official alert wording that must be reproduced exactly.
 - If you need to describe a narrow window, do it approximately without clock times (e.g., "for a couple of hours in mid-afternoon").
 - Exception: If you are quoting or paraphrasing official alert timing that includes exact clock times, reproduce those times verbatim (and make clear they come from the alert).
 

--- a/src/ibf/pipeline/executor.py
+++ b/src/ibf/pipeline/executor.py
@@ -32,6 +32,7 @@ from ..api import (
     STANDARD_PRECIPITATION_UNIT,
     STANDARD_WINDSPEED_UNIT,
     ModelSpec,
+    ImpactContext,
     resolve_model_spec,
 )
 from ..render import ForecastPage, render_forecast_page
@@ -322,6 +323,7 @@ def _process_location(location: LocationConfig, config: ForecastConfig, display_
     timezone_name = geocode.timezone or "UTC"
     impact_enabled = _as_bool(config.location_impact_based)
     ibf_context = ""
+    impact_context = None
     if impact_enabled:
         context_llm = (getattr(config, "context_llm", None) or "gemini-3.5-flash-lite").strip()
         impact_context = fetch_impact_context(
@@ -418,7 +420,7 @@ def _process_location(location: LocationConfig, config: ForecastConfig, display_
         )
 
     translation_target = _location_translation_language(location, config)
-    translated_text, translation_cost = _maybe_translate(
+    translated_text, translation_cost, translation_settings = _maybe_translate(
         forecast_text,
         translation_target,
         config,
@@ -439,6 +441,9 @@ def _process_location(location: LocationConfig, config: ForecastConfig, display_
             translated_text=translated_text,
             translation_language=translation_target,
             ibf_context=ibf_context,
+            context_provenance=_context_provenance_label(impact_context, timezone_name),
+            forecast_llm=_llm_provenance_label(llm_settings),
+            translation_llm=_llm_provenance_label(translation_settings),
             model_label=model_label,
             model_ack_url=model_ack,
         )
@@ -482,6 +487,7 @@ def _process_area(area: AreaConfig, config: ForecastConfig) -> None:
     area_timezone = payloads[0].geocode.timezone or "UTC"
     impact_enabled = _as_bool(config.area_impact_based)
     ibf_context = ""
+    impact_context = None
     if impact_enabled:
         context_llm = (getattr(config, "context_llm", None) or "gemini-3.5-flash-lite").strip()
         impact_context = fetch_impact_context(
@@ -596,7 +602,7 @@ def _process_area(area: AreaConfig, config: ForecastConfig) -> None:
         )
 
     translation_target = _area_translation_language(area, config)
-    translated_text, translation_cost = _maybe_translate(
+    translated_text, translation_cost, translation_settings = _maybe_translate(
         forecast_text,
         translation_target,
         config,
@@ -619,6 +625,9 @@ def _process_area(area: AreaConfig, config: ForecastConfig) -> None:
             translated_text=translated_text,
             translation_language=translation_target,
             ibf_context=ibf_context,
+            context_provenance=_context_provenance_label(impact_context, area_timezone),
+            forecast_llm=_llm_provenance_label(llm_settings),
+            translation_llm=_llm_provenance_label(translation_settings),
             map_link=map_link,
             model_label=model_label,
             model_ack_url=model_ack,
@@ -661,9 +670,10 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
     area_timezone = payloads[0].geocode.timezone or "UTC"
     impact_enabled = _as_bool(config.area_impact_based)
     ibf_context = ""
+    impact_context = None
     if impact_enabled:
         context_llm = (getattr(config, "context_llm", None) or "gemini-3.5-flash-lite").strip()
-        regional_context = fetch_impact_context(
+        impact_context = fetch_impact_context(
             area.name,
             context_type="regional",
             forecast_days=forecast_days,
@@ -686,8 +696,8 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
                 for payload in payloads
             ],
         )
-        ibf_context = regional_context.content
-        _record_cost("Regional", area.name, context=regional_context.cost_cents)
+        ibf_context = impact_context.content
+        _record_cost("Regional", area.name, context=impact_context.cost_cents)
         if ibf_context:
             logger.info("Fetched impact context for regional area '%s'", area.name)
         else:
@@ -777,7 +787,7 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
         )
 
     translation_target = _area_translation_language(area, config)
-    translated_text, translation_cost = _maybe_translate(
+    translated_text, translation_cost, translation_settings = _maybe_translate(
         forecast_text,
         translation_target,
         config,
@@ -800,6 +810,9 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
             translated_text=translated_text,
             translation_language=translation_target,
             ibf_context=ibf_context,
+            context_provenance=_context_provenance_label(impact_context, area_timezone),
+            forecast_llm=_llm_provenance_label(llm_settings),
+            translation_llm=_llm_provenance_label(translation_settings),
             map_link=map_link,
             model_label=model_label,
             model_ack_url=model_ack,
@@ -1795,24 +1808,92 @@ def _area_translation_language(area: AreaConfig, config: ForecastConfig) -> Opti
     return area.translation_language or config.translation_language
 
 
+def _llm_provenance_label(settings: Optional[LLMSettings]) -> Optional[str]:
+    """Return a concise public label for the model that completed an LLM operation."""
+    if settings is None:
+        return None
+    provider_names = {
+        "gemini": "Gemini",
+        "openai": "OpenAI",
+        "openrouter": "OpenRouter",
+        "lmstudio": "LM Studio",
+    }
+    provider = provider_names.get(settings.provider, settings.provider.strip().title())
+    return f"{provider} ({settings.model})" if provider else settings.model
+
+
+def _configured_model_provenance_label(model: Optional[str]) -> str:
+    """Describe a configured model identifier without resolving credentials."""
+    raw = (model or "unknown model").strip()
+    lowered = raw.lower()
+    if lowered.startswith("lms:"):
+        return f"LM Studio ({raw[4:].strip()})"
+    if lowered.startswith("or:"):
+        return f"OpenRouter ({raw[3:].strip()})"
+    if lowered.startswith("google/gemini-"):
+        return f"Gemini ({raw.split('/', 1)[1]})"
+    if lowered.startswith("gemini-"):
+        return f"Gemini ({raw})"
+    if lowered.startswith("gpt-") or (lowered.startswith("o") and lowered[1:2].isdigit()):
+        return f"OpenAI ({raw})"
+    return raw
+
+
+def _context_provenance_label(
+    context: Optional[ImpactContext],
+    timezone_name: str,
+) -> Optional[str]:
+    """Describe how and when an impact-context block was produced."""
+    if context is None or not context.content:
+        return None
+    provider = str(getattr(context, "provider", None) or "").strip().lower()
+    model = getattr(context, "model", None)
+    if provider == "brave":
+        method = f"Brave Search, summarised using {_configured_model_provenance_label(model)}"
+    elif provider == "llm-search" and (model or "").lower().lstrip().startswith(
+        ("gemini-", "google/gemini-")
+    ):
+        method = f"Gemini Google Search ({(model or '').split('/', 1)[-1]})"
+    elif provider == "llm-search":
+        method = f"OpenAI web search ({model or 'unknown model'})"
+    else:
+        method = _configured_model_provenance_label(model)
+
+    generated = getattr(context, "generated_at", None)
+    if not generated:
+        return method
+    try:
+        parsed = datetime.fromisoformat(generated.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        try:
+            parsed = parsed.astimezone(ZoneInfo(timezone_name))
+        except ZoneInfoNotFoundError:
+            pass
+        timestamp = f"{parsed.day} {parsed.strftime('%B %Y at %H:%M %Z')}"
+    except ValueError:
+        timestamp = generated
+    return f"{method}; generated {timestamp}"
+
+
 def _maybe_translate(
     text: str,
     language: Optional[str],
     config: ForecastConfig,
     llm_settings: Optional[LLMSettings],
-) -> tuple[Optional[str], float]:
+) -> tuple[Optional[str], float, Optional[LLMSettings]]:
     """Translate finished forecast text when a non-English target language is requested."""
     if not language:
-        return None, 0.0
+        return None, 0.0, None
     if language.lower().startswith("en"):
-        return None, 0.0
+        return None, 0.0, None
     if not text:
-        return None, 0.0
+        return None, 0.0, None
     try:
         chosen_model = config.translation_llm
         system_prompt = build_translation_system_prompt(language)
         user_prompt = build_translation_user_prompt(text)
-        translated, _, translation_cost = _generate_text_with_fallback(
+        translated, translation_settings, translation_cost = _generate_text_with_fallback(
             config,
             user_prompt,
             system_prompt,
@@ -1823,10 +1904,10 @@ def _maybe_translate(
             snapshot_name=language,
             operation_label=f"translation into {language}",
         )
-        return translated, translation_cost
+        return translated, translation_cost, translation_settings
     except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
         logger.error("Translation failed (%s): %s", language, exc, exc_info=True)
-        return None, 0.0
+        return None, 0.0, None
 
 
 def _generate_text_with_fallback(

--- a/src/ibf/pipeline/executor.py
+++ b/src/ibf/pipeline/executor.py
@@ -35,6 +35,7 @@ from ..api import (
     ImpactContext,
     resolve_model_spec,
 )
+from ..api.thin import select_members
 from ..render import ForecastPage, render_forecast_page
 from ..util import ensure_directory, safe_unlink, slugify, utc_now, write_text_file
 from ..util.naming import generate_unique_location_names
@@ -362,37 +363,14 @@ def _process_location(location: LocationConfig, config: ForecastConfig, display_
     forecast_text: Optional[str] = None
     if formatted_dataset and not formatted_dataset.startswith("Error"):
         try:
-            system_prompt = build_spot_system_prompt(
-                _unit_instructions(payload.units),
-                model_kind=payload.model_kind,
-            )
-            short_instr = _short_period_instruction(dataset, geocode.timezone or "UTC")
-            impact_instr = _impact_instruction(impact_enabled)
-            prompt = build_spot_user_prompt(
-                formatted_dataset,
-                location_name=name,
-                latitude=geocode.latitude,
-                longitude=geocode.longitude,
-                season=determine_current_season(geocode.latitude),
-                wordiness=(config.location_wordiness or "normal").lower(),
-                short_period_instruction=short_instr,
-                impact_instruction=impact_instr if ibf_context else "",
-                impact_context=ibf_context or "",
-                user_extra_context=location.extra_context,
-            )
-            reasoning_enabled = _as_bool(config.enable_reasoning)
-            reasoning_level = getattr(config, "location_reasoning", None)
-            forecast_text, llm_settings, forecast_cost = _generate_text_with_fallback(
-                config,
-                prompt,
-                system_prompt,
-                primary_choice=config.llm,
-                fallback_choice=config.llm_fallback,
-                snapshot_kind="location",
-                snapshot_name=name,
-                operation_label=f"forecast for {name}",
-                reasoning_enabled=reasoning_enabled,
-                reasoning_level=reasoning_level,
+            forecast_text, llm_settings, forecast_cost = (
+                _generate_location_text_with_adaptive_thinning(
+                    location,
+                    config,
+                    payload,
+                    ibf_context=ibf_context,
+                    impact_enabled=impact_enabled,
+                )
             )
             _record_cost("Location", unique_name, forecast=forecast_cost)
         except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
@@ -521,61 +499,26 @@ def _process_area(area: AreaConfig, config: ForecastConfig) -> None:
             logger.warning("No impact context will be used for area '%s'.", area.name)
     else:
         logger.info("Impact context disabled for area '%s'; skipping.", area.name)
-    formatted_dataset = format_area_dataset(
-        area.name,
-        [
-            {
-                "name": payload.name,
-                "latitude": payload.geocode.latitude,
-                "longitude": payload.geocode.longitude,
-                "timezone": payload.geocode.timezone,
-                "text": payload.formatted_dataset,
-            }
-            for payload in payloads
-        ],
-    )
-
     llm_settings = None
     forecast_text: Optional[str] = None
-    if formatted_dataset:
-        try:
-            area_kind = "ensemble" if any(p.model_kind == "ensemble" for p in payloads) else "deterministic"
-            system_prompt = build_area_system_prompt(
-                _unit_instructions(base_units),
-                model_kind=area_kind,
-            )
-            short_instr = _short_period_instruction(
-                payloads[0].dataset, payloads[0].geocode.timezone or "UTC"
-            )
-            impact_instr = _impact_instruction(impact_enabled)
-            prompt = build_area_user_prompt(
-                formatted_dataset,
-                area_name=area.name,
-                location_names=[payload.name for payload in payloads],
-                wordiness=(config.area_wordiness or config.location_wordiness or "normal").lower(),
-                short_period_instruction=short_instr,
-                impact_instruction=impact_instr if ibf_context else "",
-                impact_context=ibf_context or "",
-                user_extra_context=area.extra_context,
-            )
-            reasoning_enabled = _as_bool(config.enable_reasoning)
-            reasoning_level = getattr(config, "area_reasoning", None)
-            forecast_text, llm_settings, forecast_cost = _generate_text_with_fallback(
-                config,
-                prompt,
-                system_prompt,
-                primary_choice=config.llm,
-                fallback_choice=config.llm_fallback,
-                snapshot_kind="area",
-                snapshot_name=area.name,
-                operation_label=f"area forecast for {area.name}",
-                reasoning_enabled=reasoning_enabled,
-                reasoning_level=reasoning_level,
-            )
-            _record_cost("Area", area.name, forecast=forecast_cost)
-            logger.info("Requesting area LLM forecast for '%s' using model %s", area.name, llm_settings.model)
-        except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
-            logger.error("LLM generation failed for area %s: %s", area.name, exc, exc_info=True)
+    try:
+        forecast_text, llm_settings, forecast_cost = _generate_area_text_with_adaptive_thinning(
+            area,
+            config,
+            payloads,
+            base_units,
+            ibf_context=ibf_context,
+            impact_enabled=impact_enabled,
+            regional=False,
+        )
+        _record_cost("Area", area.name, forecast=forecast_cost)
+        logger.info(
+            "Area LLM forecast for '%s' completed using model %s",
+            area.name,
+            llm_settings.model,
+        )
+    except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
+        logger.error("LLM generation failed for area %s: %s", area.name, exc, exc_info=True)
 
     if not forecast_text:
         destination = _build_destination_path(config, area.name)
@@ -704,63 +647,28 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
             logger.warning("No impact context will be used for regional area '%s'.", area.name)
     else:
         logger.info("Impact context disabled for regional area '%s'; skipping.", area.name)
-    formatted_dataset = format_area_dataset(
-        area.name,
-        [
-            {
-                "name": payload.name,
-                "latitude": payload.geocode.latitude,
-                "longitude": payload.geocode.longitude,
-                "timezone": payload.geocode.timezone,
-                "text": payload.formatted_dataset,
-            }
-            for payload in payloads
-        ],
-    )
-
     llm_settings = None
     forecast_text: Optional[str] = None
-    if formatted_dataset:
-        try:
-            area_kind = "ensemble" if any(p.model_kind == "ensemble" for p in payloads) else "deterministic"
-            system_prompt = build_regional_system_prompt(
-                _unit_instructions(base_units),
-                model_kind=area_kind,
-            )
-            short_instr = _short_period_instruction(
-                payloads[0].dataset, payloads[0].geocode.timezone or "UTC"
-            )
-            impact_instr = _impact_instruction(impact_enabled)
-            prompt = build_regional_user_prompt(
-                formatted_dataset,
-                area_name=area.name,
-                location_names=[payload.name for payload in payloads],
-                wordiness=(config.area_wordiness or config.location_wordiness or "normal").lower(),
-                short_period_instruction=short_instr,
-                impact_instruction=impact_instr if ibf_context else "",
-                impact_context=ibf_context or "",
-                user_extra_context=area.extra_context,
-            )
-            reasoning_enabled = _as_bool(config.enable_reasoning)
-            reasoning_level = getattr(config, "area_reasoning", None)
-            forecast_text, llm_settings, forecast_cost = _generate_text_with_fallback(
-                config,
-                prompt,
-                system_prompt,
-                primary_choice=config.llm,
-                fallback_choice=config.llm_fallback,
-                snapshot_kind="regional-area",
-                snapshot_name=area.name,
-                operation_label=f"regional forecast for {area.name}",
-                reasoning_enabled=reasoning_enabled,
-                reasoning_level=reasoning_level,
-            )
-            logger.info("Requesting regional LLM forecast for '%s' using model %s", area.name, llm_settings.model)
-            _record_cost("Regional", area.name, forecast=forecast_cost)
-        except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
-            logger.error(
-                "Regional LLM generation failed for %s: %s", area.name, exc, exc_info=True
-            )
+    try:
+        forecast_text, llm_settings, forecast_cost = _generate_area_text_with_adaptive_thinning(
+            area,
+            config,
+            payloads,
+            base_units,
+            ibf_context=ibf_context,
+            impact_enabled=impact_enabled,
+            regional=True,
+        )
+        logger.info(
+            "Regional LLM forecast for '%s' completed using model %s",
+            area.name,
+            llm_settings.model,
+        )
+        _record_cost("Regional", area.name, forecast=forecast_cost)
+    except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
+        logger.error(
+            "Regional LLM generation failed for %s: %s", area.name, exc, exc_info=True
+        )
 
     if not forecast_text:
         destination = _build_destination_path(config, area.name)
@@ -819,6 +727,243 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
         )
     )
     logger.info("Rendered regional forecast page for '%s' → %s", area.name, destination)
+
+
+def _generate_location_text_with_adaptive_thinning(
+    location: LocationConfig,
+    config: ForecastConfig,
+    payload: LocationForecastPayload,
+    *,
+    ibf_context: str,
+    impact_enabled: bool,
+) -> tuple[str, LLMSettings, float]:
+    """Generate a spot forecast, reducing ensemble scenarios only after context overflow."""
+    system_prompt = build_spot_system_prompt(
+        _unit_instructions(payload.units),
+        model_kind=payload.model_kind,
+    )
+    short_instr = _short_period_instruction(
+        payload.dataset,
+        payload.geocode.timezone or "UTC",
+    )
+    impact_instr = _impact_instruction(impact_enabled)
+    operation_label = f"forecast for {payload.name}"
+    initial_scenarios = _maximum_dataset_scenarios(payload.dataset)
+    member_limits: List[Optional[int]] = [None]
+    if payload.model_kind == "ensemble":
+        member_limits.extend(_reduced_scenario_limits(initial_scenarios))
+
+    for attempt_index, member_limit in enumerate(member_limits):
+        formatted_dataset = payload.formatted_dataset
+        if member_limit is not None:
+            reduced_dataset = select_members(payload.dataset, thin_select=member_limit)
+            formatted_dataset = _format_location_payload(payload, reduced_dataset)
+        prompt = build_spot_user_prompt(
+            formatted_dataset,
+            location_name=payload.name,
+            latitude=payload.geocode.latitude,
+            longitude=payload.geocode.longitude,
+            season=determine_current_season(payload.geocode.latitude),
+            wordiness=(config.location_wordiness or "normal").lower(),
+            short_period_instruction=short_instr,
+            impact_instruction=impact_instr if ibf_context else "",
+            impact_context=ibf_context or "",
+            user_extra_context=location.extra_context,
+        )
+        if attempt_index:
+            logger.warning(
+                "Retrying %s with at most %d representative scenario(s); "
+                "estimated_input_tokens=%d.",
+                operation_label,
+                member_limit,
+                _estimate_prompt_tokens(system_prompt, prompt),
+            )
+        try:
+            return _generate_text_with_fallback(
+                config,
+                prompt,
+                system_prompt,
+                primary_choice=config.llm,
+                fallback_choice=config.llm_fallback,
+                snapshot_kind="location",
+                snapshot_name=payload.name,
+                operation_label=operation_label,
+                reasoning_enabled=_as_bool(config.enable_reasoning),
+                reasoning_level=getattr(config, "location_reasoning", None),
+            )
+        except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
+            has_smaller_retry = attempt_index + 1 < len(member_limits)
+            if not _is_context_window_error(exc) or not has_smaller_retry:
+                raise
+            current_count = initial_scenarios if member_limit is None else member_limit
+            next_count = member_limits[attempt_index + 1]
+            logger.warning(
+                "%s exceeded the available LLM context with up to %d scenario(s); "
+                "rebuilding the prompt with %d.",
+                operation_label.capitalize(),
+                current_count,
+                next_count,
+            )
+
+    raise RuntimeError(f"No usable prompt could be generated for {operation_label}.")
+
+
+def _generate_area_text_with_adaptive_thinning(
+    area: AreaConfig,
+    config: ForecastConfig,
+    payloads: List[LocationForecastPayload],
+    units: LocationUnits,
+    *,
+    ibf_context: str,
+    impact_enabled: bool,
+    regional: bool,
+) -> tuple[str, LLMSettings, float]:
+    """Generate an area forecast, reducing ensemble scenarios only after context overflow."""
+    area_kind = "ensemble" if any(p.model_kind == "ensemble" for p in payloads) else "deterministic"
+    system_prompt = (
+        build_regional_system_prompt(_unit_instructions(units), model_kind=area_kind)
+        if regional
+        else build_area_system_prompt(_unit_instructions(units), model_kind=area_kind)
+    )
+    short_instr = _short_period_instruction(
+        payloads[0].dataset,
+        payloads[0].geocode.timezone or "UTC",
+    )
+    impact_instr = _impact_instruction(impact_enabled)
+    wordiness = (config.area_wordiness or config.location_wordiness or "normal").lower()
+    operation_label = (
+        f"regional forecast for {area.name}" if regional else f"area forecast for {area.name}"
+    )
+    prompt_builder = build_regional_user_prompt if regional else build_area_user_prompt
+    initial_scenarios = _maximum_ensemble_scenarios(payloads)
+    member_limits: List[Optional[int]] = [None]
+    member_limits.extend(_reduced_scenario_limits(initial_scenarios))
+
+    for attempt_index, member_limit in enumerate(member_limits):
+        formatted_dataset = _format_area_payloads(
+            area.name,
+            payloads,
+            member_limit=member_limit,
+        )
+        prompt = prompt_builder(
+            formatted_dataset,
+            area_name=area.name,
+            location_names=[payload.name for payload in payloads],
+            wordiness=wordiness,
+            short_period_instruction=short_instr,
+            impact_instruction=impact_instr if ibf_context else "",
+            impact_context=ibf_context or "",
+            user_extra_context=area.extra_context,
+        )
+        if attempt_index:
+            logger.warning(
+                "Retrying %s with at most %d representative scenario(s) per ensemble "
+                "location; estimated_input_tokens=%d.",
+                operation_label,
+                member_limit,
+                _estimate_prompt_tokens(system_prompt, prompt),
+            )
+        try:
+            return _generate_text_with_fallback(
+                config,
+                prompt,
+                system_prompt,
+                primary_choice=config.llm,
+                fallback_choice=config.llm_fallback,
+                snapshot_kind="regional-area" if regional else "area",
+                snapshot_name=area.name,
+                operation_label=operation_label,
+                reasoning_enabled=_as_bool(config.enable_reasoning),
+                reasoning_level=getattr(config, "area_reasoning", None),
+            )
+        except (OpenAIError, OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
+            has_smaller_retry = attempt_index + 1 < len(member_limits)
+            if not _is_context_window_error(exc) or not has_smaller_retry:
+                raise
+            current_count = initial_scenarios if member_limit is None else member_limit
+            next_count = member_limits[attempt_index + 1]
+            logger.warning(
+                "%s exceeded the available LLM context with up to %d scenario(s) per "
+                "ensemble location; rebuilding the prompt with %d.",
+                operation_label.capitalize(),
+                current_count,
+                next_count,
+            )
+
+    raise RuntimeError(f"No usable prompt could be generated for {operation_label}.")
+
+
+def _format_area_payloads(
+    area_name: str,
+    payloads: List[LocationForecastPayload],
+    *,
+    member_limit: Optional[int],
+) -> str:
+    """Format area inputs, optionally re-thinning retained ensemble scenarios."""
+    locations = []
+    for payload in payloads:
+        text = payload.formatted_dataset
+        if member_limit is not None and payload.model_kind == "ensemble":
+            reduced_dataset = select_members(payload.dataset, thin_select=member_limit)
+            text = _format_location_payload(payload, reduced_dataset)
+        locations.append(
+            {
+                "name": payload.name,
+                "latitude": payload.geocode.latitude,
+                "longitude": payload.geocode.longitude,
+                "timezone": payload.geocode.timezone,
+                "text": text,
+            }
+        )
+    return format_area_dataset(area_name, locations)
+
+
+def _maximum_ensemble_scenarios(payloads: List[LocationForecastPayload]) -> int:
+    """Return the largest retained scenario count among ensemble location payloads."""
+    maximum = 0
+    for payload in payloads:
+        if payload.model_kind != "ensemble":
+            continue
+        maximum = max(maximum, _maximum_dataset_scenarios(payload.dataset))
+    return maximum
+
+
+def _maximum_dataset_scenarios(dataset: List[dict]) -> int:
+    """Return the largest ensemble-member count in a processed dataset."""
+    maximum = 0
+    for day in dataset:
+        for hour in day.get("hours", []):
+            members = hour.get("ensemble_members", {})
+            if isinstance(members, dict):
+                maximum = max(maximum, len(members))
+    return maximum
+
+
+def _format_location_payload(
+    payload: LocationForecastPayload,
+    dataset: List[dict],
+) -> str:
+    """Format a payload's dataset using its location-specific units and alerts."""
+    return format_location_dataset(
+        dataset,
+        payload.alerts,
+        payload.geocode.timezone or "UTC",
+        temperature_unit=payload.units.temperature_primary,
+        precipitation_unit=payload.units.precipitation_primary,
+        snowfall_unit=payload.units.snowfall_primary,
+        windspeed_unit=payload.units.windspeed_primary,
+    )
+
+
+def _reduced_scenario_limits(initial: int) -> List[int]:
+    """Return progressively halved scenario limits down to one member."""
+    limits: List[int] = []
+    current = initial
+    while current > 1:
+        current = max(1, current // 2)
+        if not limits or current != limits[-1]:
+            limits.append(current)
+    return limits
 
 
 def _collect_location_payload(
@@ -2029,10 +2174,12 @@ def _log_prompt_size(
     user_chars = len(user_prompt)
     total_chars = system_chars + user_chars
     total_bytes = len(system_prompt.encode("utf-8")) + len(user_prompt.encode("utf-8"))
-    estimated_tokens = max(1, (total_chars + 3) // 4)
+    estimated_tokens = _estimate_prompt_tokens(system_prompt, user_prompt)
+    estimated_context_tokens = estimated_tokens + settings.max_tokens
     logger.info(
         "LLM prompt size – operation=%s model=%s system_chars=%d user_chars=%d "
-        "total_chars=%d utf8_bytes=%d estimated_input_tokens=%d max_output_tokens=%d",
+        "total_chars=%d utf8_bytes=%d estimated_input_tokens=%d max_output_tokens=%d "
+        "estimated_context_tokens=%d",
         operation_label,
         settings.model,
         system_chars,
@@ -2041,7 +2188,14 @@ def _log_prompt_size(
         total_bytes,
         estimated_tokens,
         settings.max_tokens,
+        estimated_context_tokens,
     )
+
+
+def _estimate_prompt_tokens(system_prompt: str, user_prompt: str) -> int:
+    """Return a provider-neutral rough input-token estimate based on character count."""
+    total_chars = len(system_prompt) + len(user_prompt)
+    return max(1, (total_chars + 3) // 4)
 
 
 def _is_context_window_error(exc: BaseException) -> bool:
@@ -2052,8 +2206,12 @@ def _is_context_window_error(exc: BaseException) -> bool:
         for marker in (
             "greater than the context length",
             "exceeded the context length",
+            "exceeded the model's context size",
+            "exceeded the model context size",
             "maximum context length",
+            "context size",
             "context window",
+            "context overflow",
             "too many tokens",
         )
     )

--- a/src/ibf/render/html.py
+++ b/src/ibf/render/html.py
@@ -25,6 +25,9 @@ class ForecastPage:
         translated_text: Optional translated forecast body.
         translation_language: Language code for the translated forecast.
         ibf_context: Optional IBF context block in Markdown.
+        context_provenance: Optional provider, model, and generation-time description.
+        forecast_llm: Model that wrote the forecast.
+        translation_llm: Model that translated the forecast, if applicable.
         map_link: Optional link to a generated map.
         model_label: Label for the data source/model.
         model_ack_url: Optional acknowledgement URL for the model data.
@@ -36,6 +39,9 @@ class ForecastPage:
     translated_text: Optional[str] = None
     translation_language: Optional[str] = None
     ibf_context: Optional[str] = None
+    context_provenance: Optional[str] = None
+    forecast_llm: Optional[str] = None
+    translation_llm: Optional[str] = None
     map_link: Optional[str] = None
     model_label: str = "ECMWF IFS 0.25° ensemble"
     model_ack_url: Optional[str] = None
@@ -54,7 +60,7 @@ def render_forecast_page(page: ForecastPage) -> Path:
         page.translated_text,
         page.translation_language,
     )
-    ibf_html = _render_ibf_block(page.ibf_context)
+    ibf_html = _render_ibf_block(page.ibf_context, page.context_provenance)
 
     body_parts = [
         f"<h1>Forecast for {display_name}</h1>",
@@ -81,13 +87,29 @@ def render_forecast_page(page: ForecastPage) -> Path:
     if page.model_ack_url:
         safe_ack_url = html.escape(page.model_ack_url, quote=True)
         footer_ack = f'  Additional acknowledgement: <a href="{safe_ack_url}" target="_blank" rel="noopener">open data licence</a>.<br>'
+    model_provenance_lines = []
+    if page.forecast_llm:
+        model_provenance_lines.append(
+            f"Forecast language model: {html.escape(page.forecast_llm, quote=True)}."
+        )
+    if page.translation_llm:
+        model_provenance_lines.append(
+            f"Translation language model: {html.escape(page.translation_llm, quote=True)}."
+        )
+    model_provenance = ""
+    if model_provenance_lines:
+        model_provenance = (
+            '<div class="footer-model-provenance">'
+            + "<br>".join(model_provenance_lines)
+            + "</div>"
+        )
     body_parts.extend(
         [
             '<p><a href="../index.html">Return to Menu</a></p>',
             f"""<div class="footer-note">
   Forecast produced using <a href="https://github.com/tehoro/ibf" target="_blank" rel="noopener">IBF</a>, developed by <a href="mailto:neil.gordon@hey.com?subject=Comment%20on%20IBF">Neil Gordon</a>.
   Data courtesy of <a href="https://open-meteo.com/" target="_blank" rel="noopener">open-meteo.com</a> using {safe_model_label}.
-{footer_ack}  If you want to interactively request a forecast for a location, visit the <a href="https://chatgpt.com/g/g-4OgZFHOPA-global-ensemble-weather-forecaster" target="_blank" rel="noopener">Global Ensemble Weather Forecaster</a> (ChatGPT account required).
+{footer_ack}{model_provenance}  If you want to interactively request a forecast for a location, visit the <a href="https://chatgpt.com/g/g-4OgZFHOPA-global-ensemble-weather-forecaster" target="_blank" rel="noopener">Global Ensemble Weather Forecaster</a> (ChatGPT account required).
 </div>""",
         ]
     )
@@ -185,17 +207,26 @@ def _render_translation_block(text: Optional[str], language: Optional[str]) -> t
     return _markdown_to_html(text), header
 
 
-def _render_ibf_block(context: Optional[str]) -> Optional[str]:
+def _render_ibf_block(
+    context: Optional[str],
+    provenance: Optional[str] = None,
+) -> Optional[str]:
     """Render the optional IBF context block for the forecast page."""
     if not context:
         return None
     context_html = _markdown_to_html(context)
+    provenance_html = ""
+    if provenance:
+        provenance_html = (
+            '<p class="ibf-context-provenance">Context source: '
+            f"{html.escape(provenance, quote=True)}.</p>"
+        )
     return f"""<div id="ibf-context-wrapper">
   <div id="ibf-context-header" onclick="toggleIbfContext()">
     <span id="ibf-context-toggle">▶</span>
     <span id="ibf-context-header-text">Impact-Based Forecast Context</span>
   </div>
-  <div id="ibf-context-content">{context_html}</div>
+  <div id="ibf-context-content">{context_html}{provenance_html}</div>
 </div>"""
 
 
@@ -219,12 +250,14 @@ h3 { color: #495057; font-size: 1.1em; font-weight: 600; margin-top: 0.8em; marg
 #ibf-context-content ul { margin: 0 0 1em 1.2em; padding: 0; }
 #ibf-context-content li { margin-bottom: 0.5em; }
 #ibf-context-content li:last-child { margin-bottom: 0; }
+.ibf-context-provenance { margin: 1.5em 0 0; padding-top: 0.8em; border-top: 1px solid #dee2e6; color: #6c757d; font-size: 0.85em; }
 #ibf-context-content.expanded { display: block; }
 h2 { color: #343a40; margin-top: 1.5em; margin-bottom: 0.8em; font-size: 1.4em; }
 a { color: #0d6efd; text-decoration: none; font-weight: 500; }
 a:hover { text-decoration: underline; color: #0a58ca; }
 .footer-note { margin-top: 2.5em; padding-top: 1em; border-top: 1px solid #dee2e6; font-size: 0.9em; color: #6c757d; text-align: center; }
 .footer-note a { font-weight: normal; }
+.footer-model-provenance { margin: 0.35em 0; }
 hr { display: none; }
 @media (max-width: 600px) { body { margin: 0.5em; padding: 0 0.8em; } h1 { font-size: 1.5em; } #forecast-content, #translated-forecast-content, #ibf-context-content { padding: 1em 1.2em; } h2 { font-size: 1.2em;} }
 </style>"""

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from ibf import cli
-from ibf.config.models import AreaConfig, ForecastConfig
+from ibf.config.models import AreaConfig, ForecastConfig, LocationConfig
 from ibf.pipeline import executor
 from ibf.pipeline.executor import (
     ForecastGenerationFailure,
@@ -200,6 +200,114 @@ def test_failed_area_forecast_is_not_translated_or_replaced_with_dataset_paths(
     assert "Area dataset preview" not in html
     assert str(payload.dataset_cache) not in html
     assert "Forecast in Spanish" not in html
+
+
+def test_area_context_overflow_retries_with_half_the_scenarios(
+    tmp_path,
+    monkeypatch,
+    caplog,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    payload = _make_mock_payload("Test City", cache_dir)
+    members = payload.dataset[0]["hours"][0]["ensemble_members"]
+    control = members["member00"]
+    for index in range(1, 8):
+        members[f"member{index:02d}"] = {
+            **control,
+            "temperature": control["temperature"] + index,
+            "precipitation": control["precipitation"] + index / 10,
+        }
+
+    area = AreaConfig(name="Test Area", locations=["Test City"])
+    config = ForecastConfig(llm="lms:apple-pcc", area_wordiness="brief")
+    settings = LLMSettings(
+        model="apple-pcc",
+        api_key="local",
+        provider="lmstudio",
+        base_url="http://localhost:1235/v1",
+    )
+    prompts = []
+
+    def fake_generate(_config, prompt, _system_prompt, **_kwargs):
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            raise RuntimeError("The session's transcript exceeded the model's context size.")
+        return "Reduced forecast", settings, 0.0
+
+    monkeypatch.setattr(executor, "_generate_text_with_fallback", fake_generate)
+
+    with caplog.at_level("WARNING"):
+        text, used_settings, cost = executor._generate_area_text_with_adaptive_thinning(
+            area,
+            config,
+            [payload],
+            payload.units,
+            ibf_context="",
+            impact_enabled=False,
+            regional=False,
+        )
+
+    assert text == "Reduced forecast"
+    assert used_settings is settings
+    assert cost == 0.0
+    assert len(prompts) == 2
+    assert prompts[1].count("Scenario ") == 4
+    assert "rebuilding the prompt with 4" in caplog.text
+    assert "estimated_input_tokens=" in caplog.text
+
+
+def test_location_context_overflow_retries_with_half_the_scenarios(
+    tmp_path,
+    monkeypatch,
+    caplog,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    payload = _make_mock_payload("Test City", cache_dir)
+    members = payload.dataset[0]["hours"][0]["ensemble_members"]
+    control = members["member00"]
+    for index in range(1, 8):
+        members[f"member{index:02d}"] = {
+            **control,
+            "temperature": control["temperature"] + index,
+            "precipitation": control["precipitation"] + index / 10,
+        }
+
+    location = LocationConfig(name="Test City")
+    config = ForecastConfig(llm="lms:apple-pcc", location_wordiness="normal")
+    settings = LLMSettings(
+        model="apple-pcc",
+        api_key="local",
+        provider="lmstudio",
+        base_url="http://localhost:1235/v1",
+    )
+    prompts = []
+
+    def fake_generate(_config, prompt, _system_prompt, **_kwargs):
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            raise RuntimeError("The session's transcript exceeded the model's context size.")
+        return "Reduced forecast", settings, 0.0
+
+    monkeypatch.setattr(executor, "_generate_text_with_fallback", fake_generate)
+
+    with caplog.at_level("WARNING"):
+        text, used_settings, cost = executor._generate_location_text_with_adaptive_thinning(
+            location,
+            config,
+            payload,
+            ibf_context="",
+            impact_enabled=False,
+        )
+
+    assert text == "Reduced forecast"
+    assert used_settings is settings
+    assert cost == 0.0
+    assert len(prompts) == 2
+    assert prompts[1].count("Scenario ") == 4
+    assert "rebuilding the prompt with 4" in caplog.text
+    assert "estimated_input_tokens=" in caplog.text
 
 
 def test_execute_pipeline_collects_failures_and_continues(monkeypatch) -> None:

--- a/tests/test_cli_pipeline.py
+++ b/tests/test_cli_pipeline.py
@@ -139,6 +139,8 @@ def test_cli_run_generates_forecasts(
     html = area_page.read_text(encoding="utf-8")
     assert "Show map for Sample Area" in html
     assert f"../maps/{slugify('Sample Area')}.png" in html
+    assert "Forecast language model: Mock (mock-model)." in html
+    assert "Translation language model: Mock (mock-translation)." in html
 
     hash_file = web_root / ".ibf_maps_hash"
     assert hash_file.exists()

--- a/tests/test_formatter_units.py
+++ b/tests/test_formatter_units.py
@@ -107,6 +107,24 @@ def test_range_summary_collapses_rounded_precipitation_and_snowfall_endpoints() 
     assert "2 cm to 2 cm" not in summary
 
 
+def test_range_summary_omits_precipitation_amount_when_upper_end_rounds_to_zero() -> None:
+    summary = calculate_range_summary(
+        [10, 11, 12],
+        [20, 21, 22],
+        [0, 0, 0.1, 0.2, 0.3],
+        [0, 0, 0, 0, 0],
+        "C",
+        "mm",
+        "cm",
+        False,
+        False,
+    )
+
+    assert "Estimated probability of precipitation:" in summary
+    assert "Likely precipitation" not in summary
+    assert "0 mm" not in summary
+
+
 def test_formatter_skips_alert_with_invalid_timestamps(caplog) -> None:
     alert = AlertSummary(
         title="Invalid alert",

--- a/tests/test_formatter_units.py
+++ b/tests/test_formatter_units.py
@@ -125,6 +125,40 @@ def test_range_summary_omits_precipitation_amount_when_upper_end_rounds_to_zero(
     assert "0 mm" not in summary
 
 
+def test_range_summary_uses_up_to_when_precipitation_lower_end_rounds_to_zero() -> None:
+    summary = calculate_range_summary(
+        [10, 11, 12],
+        [20, 21, 22],
+        [0, 0, 0.1, 0.2, 0.3, 3.0, 3.2],
+        [0, 0, 0, 0, 0, 0, 0],
+        "C",
+        "mm",
+        "cm",
+        False,
+        False,
+    )
+
+    assert "Likely precipitation up to 3 mm" in summary
+    assert "0 mm to 3 mm" not in summary
+
+
+def test_range_summary_uses_up_to_for_subunit_inch_lower_end() -> None:
+    summary = calculate_range_summary(
+        [50, 51, 52],
+        [70, 71, 72],
+        [0, 0.001, 0.01, 0.02, 0.1, 0.12],
+        [0, 0, 0, 0, 0, 0],
+        "F",
+        "inch",
+        "inch",
+        False,
+        False,
+    )
+
+    assert "Likely precipitation up to 0.1 in" in summary
+    assert "0.0 in to 0.1 in" not in summary
+
+
 def test_formatter_skips_alert_with_invalid_timestamps(caplog) -> None:
     alert = AlertSummary(
         title="Invalid alert",

--- a/tests/test_impact_context.py
+++ b/tests/test_impact_context.py
@@ -23,6 +23,7 @@ from ibf.api.impact import (
     _generate_context_gemini_search,
     _generate_context_openai_web_search,
     _filter_invalid_upcoming_event_bullets,
+    _load_context_provenance,
     _repair_brave_synthesis_structure,
     _store_hosted_search_sidecar,
     _strip_private_source_markers,
@@ -540,6 +541,31 @@ def test_modern_impact_cache_key_includes_forecast_days(tmp_path, monkeypatch) -
     assert "_7" in seven_days.name
 
 
+def test_context_cache_provenance_round_trips(tmp_path: Path) -> None:
+    cache_path = tmp_path / "context.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "context": "Context",
+                "timestamp": "2026-07-28T08:30:00+12:00",
+                "source_provider": "brave",
+                "source_model": "lms:gemma-4-12b-it",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    provider, model, generated_at = _load_context_provenance(
+        cache_path,
+        default_provider="llm-search",
+        default_model="gemini-3.5-flash",
+    )
+
+    assert provider == "brave"
+    assert model == "lms:gemma-4-12b-it"
+    assert generated_at == "2026-07-28T08:30:00+12:00"
+
+
 def test_new_default_context_model_does_not_share_legacy_unsuffixed_cache_key(
     tmp_path, monkeypatch
 ) -> None:
@@ -592,3 +618,6 @@ def test_brave_failure_can_fall_back_to_explicit_hosted_search_model(monkeypatch
     assert seen["model"] == "gemini-3-flash-preview"
     assert result.content.endswith("Hosted fallback.")
     assert result.cost_cents == 2.25
+    assert result.provider == "llm-search"
+    assert result.model == "gemini-3-flash-preview"
+    assert result.generated_at is not None

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -6,7 +6,7 @@ import pytest
 
 from ibf.config.models import ForecastConfig
 from ibf.llm.settings import LLMSettings
-from ibf.pipeline.executor import _generate_text_with_fallback
+from ibf.pipeline.executor import _generate_text_with_fallback, _is_context_window_error
 
 
 def test_primary_llm_failure_uses_configured_fallback(monkeypatch, caplog) -> None:
@@ -171,3 +171,12 @@ def test_lmstudio_context_overflow_logs_specific_guidance(monkeypatch, caplog) -
         )
 
     assert "prompt exceeded the model's loaded context window" in caplog.text
+
+
+def test_apple_pcc_context_size_error_is_recognised() -> None:
+    error = RuntimeError(
+        "Apple Foundation Models request failed: "
+        "The session's transcript exceeded the model's context size."
+    )
+
+    assert _is_context_window_error(error) is True

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -42,3 +42,37 @@ def test_forecast_prompts_do_not_require_invented_precipitation_totals(
     assert "Never invent or infer an amount" in prompt
     assert "never report a zero total" in prompt
     assert "Do not mention precipitation without giving an amount" not in prompt
+
+
+@pytest.mark.parametrize(
+    ("builder", "model_kind"),
+    [
+        (build_spot_system_prompt, "ensemble"),
+        (build_spot_system_prompt, "deterministic"),
+        (build_area_system_prompt, "ensemble"),
+        (build_area_system_prompt, "deterministic"),
+        (build_regional_system_prompt, "ensemble"),
+        (build_regional_system_prompt, "deterministic"),
+    ],
+)
+def test_forecast_prompts_assign_late_night_hours_to_the_correct_day(
+    builder,
+    model_kind: str,
+) -> None:
+    units = UnitInstructions(
+        temperature_primary="celsius",
+        temperature_secondary=None,
+        precipitation_primary="mm",
+        precipitation_secondary=None,
+        snowfall_primary="cm",
+        snowfall_secondary=None,
+        windspeed_primary="kph",
+        windspeed_secondary=None,
+    )
+
+    prompt = builder(units, model_kind=model_kind)
+
+    assert 'Do not use "overnight" as a forecast timing label' in prompt
+    assert "midnight through before sunrise" in prompt
+    assert "preceding day are late evening" in prompt
+    assert "overnight; towards dawn" not in prompt

--- a/tests/test_render_html.py
+++ b/tests/test_render_html.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from ibf.render import ForecastPage, render_forecast_page
+
+
+def test_forecast_page_renders_llm_and_context_provenance(tmp_path: Path) -> None:
+    destination = tmp_path / "forecast" / "index.html"
+    render_forecast_page(
+        ForecastPage(
+            destination=destination,
+            display_name="Otaki, New Zealand",
+            issue_time="2026-07-28 09:00 NZST",
+            forecast_text="**Tuesday, 28 July:** Fine.",
+            translated_text="**Tūrei, 28 Hūrae:** Ka pai.",
+            translation_language="Māori",
+            ibf_context="### Existing Vulnerabilities\n• Flood-prone road.",
+            context_provenance=(
+                "Gemini Google Search (gemini-3.5-flash); "
+                "generated 28 July 2026 at 08:30 NZST"
+            ),
+            forecast_llm="Gemini (gemini-3.5-flash-lite)",
+            translation_llm="LM Studio (gemma-4-12b-it)",
+        )
+    )
+
+    rendered = destination.read_text(encoding="utf-8")
+    assert "Forecast language model: Gemini (gemini-3.5-flash-lite)." in rendered
+    assert "Translation language model: LM Studio (gemma-4-12b-it)." in rendered
+    assert "Context source: Gemini Google Search (gemini-3.5-flash)" in rendered
+    assert "generated 28 July 2026 at 08:30 NZST" in rendered
+    assert rendered.index("Data courtesy") < rendered.index("Forecast language model")
+    assert rendered.index("Forecast language model") < rendered.index(
+        "If you want to interactively request"
+    )
+
+
+def test_forecast_page_escapes_provenance_labels(tmp_path: Path) -> None:
+    destination = tmp_path / "forecast" / "index.html"
+    render_forecast_page(
+        ForecastPage(
+            destination=destination,
+            display_name="Test",
+            issue_time="now",
+            forecast_text="Fine.",
+            ibf_context="Context.",
+            context_provenance="provider <unsafe>",
+            forecast_llm="model <unsafe>",
+        )
+    )
+
+    rendered = destination.read_text(encoding="utf-8")
+    assert "provider &lt;unsafe&gt;" in rendered
+    assert "model &lt;unsafe&gt;" in rendered
+    assert "provider <unsafe>" not in rendered
+    assert "model <unsafe>" not in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "ibf"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## Summary

Prepare the IBF 0.8.1 patch release with several forecast-output and reliability refinements made after 0.8.0.

- omit precipitation amounts that round to zero and present zero-based ranges as “up to”
- keep calendar-day timing language accurate, avoiding misleading “overnight” wording
- show the forecast, translation, and impact-context model provenance in generated pages
- estimate prompt/context token requirements and recover from explicit context overflows by progressively reducing representative ensemble scenarios for location, area, and regional forecasts
- update package and citation metadata to 0.8.1

## Why

These changes prevent awkward or misleading forecast wording, make generated output more auditable, and allow smaller-context local models to recover from oversized ensemble prompts without refetching weather data.

## Validation

- `uv run pytest -q` — 102 passed
- `uv run ibf --version` — 0.8.1
- `git diff --check`
