### PR TITLE
Release v0.8.3: fix packaged version reporting

### DIFF
--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Build binary
         run: |
           python -m PyInstaller --clean --onefile --name ibf \
+            --copy-metadata ibf \
             --add-data "assets/terrain/global_terrain_ultra_compressed.pkl.gz:assets/terrain" \
             packaging/ibf_entrypoint.py
+
+      - name: Verify packaged version
+        run: python packaging/check_binary_version.py dist/ibf
 
       - name: Import signing certificate
         id: codesign
@@ -111,8 +115,12 @@ jobs:
       - name: Build binary
         run: |
           python -m PyInstaller --clean --onefile --name ibf \
+            --copy-metadata ibf \
             --add-data "assets/terrain/global_terrain_ultra_compressed.pkl.gz:assets/terrain" \
             packaging/ibf_entrypoint.py
+
+      - name: Verify packaged version
+        run: python packaging/check_binary_version.py dist/ibf
 
       - name: Import signing certificate
         id: codesign
@@ -192,10 +200,10 @@ jobs:
 
       - name: Build binary
         run: |
-          python -m PyInstaller --clean --onefile --name ibf --add-data "assets/terrain/global_terrain_ultra_compressed.pkl.gz;assets/terrain" packaging/ibf_entrypoint.py
+          python -m PyInstaller --clean --onefile --name ibf --copy-metadata ibf --add-data "assets/terrain/global_terrain_ultra_compressed.pkl.gz;assets/terrain" packaging/ibf_entrypoint.py
 
-      - name: Smoke test
-        run: .\dist\ibf.exe --version
+      - name: Verify packaged version
+        run: python packaging/check_binary_version.py dist\ibf.exe
 
       - name: Package release
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - family-names: Gordon
     given-names: Neil
     orcid: "https://orcid.org/0000-0002-7664-9434"
-version: "0.8.2"
+version: "0.8.3"
 date-released: "2026-07-28"
 repository-code: "https://github.com/tehoro/ibf"
 url: "https://github.com/tehoro/ibf"
@@ -35,6 +35,6 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-7664-9434"
   title: "IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts"
   year: 2026
-  version: "0.8.2"
+  version: "0.8.3"
   url: "https://github.com/tehoro/ibf"
   license: Apache-2.0

--- a/packaging/check_binary_version.py
+++ b/packaging/check_binary_version.py
@@ -1,0 +1,38 @@
+"""Verify that a packaged IBF executable reports the project release version."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: check_binary_version.py PATH_TO_IBF_EXECUTABLE")
+
+    project_root = Path(__file__).resolve().parents[1]
+    with (project_root / "pyproject.toml").open("rb") as handle:
+        expected = tomllib.load(handle)["project"]["version"]
+
+    completed = subprocess.run(
+        [sys.argv[1], "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part).strip()
+    if output:
+        print(output)
+
+    expected_text = f"ibf {expected}"
+    if completed.returncode != 0 or expected_text not in output:
+        raise SystemExit(
+            f"packaged version check failed: expected {expected_text!r}, "
+            f"exit code {completed.returncode}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibf"
-version = "0.8.2"
+version = "0.8.3"
 description = "Unified impact-based forecast CLI and service"
 readme = "README.md"
 authors = [

--- a/src/ibf/__init__.py
+++ b/src/ibf/__init__.py
@@ -4,9 +4,17 @@ Core package for the unified Impact-Based Forecast tooling.
 
 from importlib import metadata as _metadata
 
-try:
-    __version__ = _metadata.version("ibf")
-except _metadata.PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.0.0"
+_EMBEDDED_VERSION = "0.8.3"
+
+
+def _resolve_version() -> str:
+    """Return installed metadata when available, or the frozen-app version."""
+    try:
+        return _metadata.version("ibf")
+    except _metadata.PackageNotFoundError:
+        return _EMBEDDED_VERSION
+
+
+__version__ = _resolve_version()
 
 __all__ = ["__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import tomllib
+
+import ibf
+
+
+def test_embedded_version_matches_project_version() -> None:
+    project_file = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with project_file.open("rb") as handle:
+        project_version = tomllib.load(handle)["project"]["version"]
+
+    assert ibf._EMBEDDED_VERSION == project_version
+
+
+def test_version_falls_back_to_embedded_version(monkeypatch) -> None:
+    def missing_distribution(_name: str) -> str:
+        raise ibf._metadata.PackageNotFoundError("ibf")
+
+    monkeypatch.setattr(ibf._metadata, "version", missing_distribution)
+
+    assert ibf._resolve_version() == ibf._EMBEDDED_VERSION

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "ibf"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## Summary

- embed the IBF release version as a fallback when installed package metadata is unavailable in a frozen app
- copy IBF package metadata into PyInstaller releases
- verify that every macOS and Windows release binary reports the exact version from `pyproject.toml` before upload
- add regression tests that keep the embedded version synchronized

This supersedes v0.8.2, whose packaged executables could display `IBF 0.0.0` in generated page footers.

## Verification

- `uv run pytest -q` — 109 passed
- locally compiled macOS arm64 executable — `ibf 0.8.3`
