### PR TITLE
Release v0.8.4: improve ensemble forecast presentation

### DIFF
--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -9,7 +9,17 @@ permissions:
   contents: write
 
 jobs:
+  release_metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      title: ${{ steps.release_title.outputs.title }}
+    steps:
+      - name: Set release title
+        id: release_title
+        run: echo "title=IBF ${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
   build-macos-arm64:
+    needs: release_metadata
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -91,11 +101,13 @@ jobs:
       - name: Publish release assets
         uses: softprops/action-gh-release@v3
         with:
+          name: ${{ needs.release_metadata.outputs.title }}
           files: |
             ibf-macos-arm64.zip
             ibf-macos-arm64.zip.sha256
 
   build-macos-x86_64:
+    needs: release_metadata
     runs-on: macos-15-intel
     steps:
       - name: Checkout
@@ -177,11 +189,13 @@ jobs:
       - name: Publish release assets
         uses: softprops/action-gh-release@v3
         with:
+          name: ${{ needs.release_metadata.outputs.title }}
           files: |
             ibf-macos-x86_64.zip
             ibf-macos-x86_64.zip.sha256
 
   build-windows-x86_64:
+    needs: release_metadata
     runs-on: windows-2022
     steps:
       - name: Checkout
@@ -214,6 +228,7 @@ jobs:
       - name: Publish release assets
         uses: softprops/action-gh-release@v3
         with:
+          name: ${{ needs.release_metadata.outputs.title }}
           files: |
             ibf-windows-x86_64.zip
             ibf-windows-x86_64.zip.sha256

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - family-names: Gordon
     given-names: Neil
     orcid: "https://orcid.org/0000-0002-7664-9434"
-version: "0.8.3"
+version: "0.8.4"
 date-released: "2026-07-28"
 repository-code: "https://github.com/tehoro/ibf"
 url: "https://github.com/tehoro/ibf"
@@ -35,6 +35,6 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-7664-9434"
   title: "IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts"
   year: 2026
-  version: "0.8.3"
+  version: "0.8.4"
   url: "https://github.com/tehoro/ibf"
   license: Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibf"
-version = "0.8.3"
+version = "0.8.4"
 description = "Unified impact-based forecast CLI and service"
 readme = "README.md"
 authors = [

--- a/src/ibf/__init__.py
+++ b/src/ibf/__init__.py
@@ -4,7 +4,7 @@ Core package for the unified Impact-Based Forecast tooling.
 
 from importlib import metadata as _metadata
 
-_EMBEDDED_VERSION = "0.8.3"
+_EMBEDDED_VERSION = "0.8.4"
 
 
 def _resolve_version() -> str:

--- a/src/ibf/llm/formatter.py
+++ b/src/ibf/llm/formatter.py
@@ -249,8 +249,8 @@ def format_location_dataset(
                 members_output.append("\n".join(block_lines))
 
                 if math.isfinite(high_temp) and math.isfinite(low_temp):
-                    daily_highs.append(round(high_temp))
-                    daily_lows.append(round(low_temp))
+                    daily_highs.append(float(high_temp))
+                    daily_lows.append(float(low_temp))
                 daily_precip.append(_normalize_daily_total(total_precip, precipitation_unit, kind="rainfall"))
                 daily_snow.append(round(total_snow, 1))
 
@@ -620,11 +620,22 @@ def calculate_range_summary(
 
 
 def _format_temperature_range(label: str, values: List[float], unit: str) -> str:
-    """Format a temperature range without ever emitting an ``X to X`` span."""
-    lower = min(values)
-    upper = max(values)
-    if lower == upper:
-        return f"Likely {label} {lower}°{unit}"
+    """Format one median value for narrow spreads, otherwise a rounded range."""
+    numeric = [
+        float(value)
+        for value in values
+        if isinstance(value, (int, float)) and math.isfinite(value)
+    ]
+    if not numeric:
+        return ""
+
+    rounded_values = [_round_half_up(value) for value in numeric]
+    lower = min(rounded_values)
+    upper = max(rounded_values)
+    collapse_span = 2 if unit.upper() == "F" else 1
+    if upper - lower <= collapse_span:
+        median = _round_half_up(float(np.median(numeric)))
+        return f"Likely {label} {median}°{unit}"
     return f"Likely {label} {lower}°{unit} to {upper}°{unit}"
 
 

--- a/src/ibf/llm/prompts.py
+++ b/src/ibf/llm/prompts.py
@@ -37,7 +37,7 @@ SYSTEM_PROMPT_SPOT_ENSEMBLE = """
 You are an expert meteorologist, skilled in evaluating and summarizing weather model information in terms of generally expected forecast conditions for a location, along with important forecast uncertainties or confidence.
 
 #USE THE FORECAST DATA
-You have been provided below with forecast data representing a range of possibilities due to inherent uncertainty in weather prediction for the exact same location. These are not forecasts for different geographic areas but different possible weather outcomes for the same location. Avoid any phrasing that could be interpreted as referring to geographic or area-specific variations. For instance, don't say "locally heavy" or "scattered showers" or "about the coast" or "in some areas".
+You have been provided below with forecast data representing a range of possibilities due to inherent uncertainty in weather prediction for the exact same location. This is a single-point forecast: differences between Scenario blocks are different possible futures at that one location, never differences between places. The Scenario labels are internal data labels only: never use them, or refer to models, members, ensembles, runs, or the forecasting process, in the reader-facing forecast. Never turn disagreement between Scenario blocks into spatial wording such as "in some areas", "in places", "elsewhere", or "locally". Mention geography only when it is explicitly supported by the location context or a supplied snow-level note, not as an explanation for differences between Scenario blocks.
 
 #FORECAST DAYS
 Always refer to the date and specific day of the week exactly as mentioned in the data. This should be written as bold text at the start of a new paragraph .. for example, "**Rest of Today, 10 January:**" or "**Friday, 12 January:**" .. followed immediately by the forecast text in the same paragraph. Use all the available days provided in the data. Do NOT add extra days or dates beyond those provided.
@@ -62,7 +62,7 @@ Always refer to the date and specific day of the week exactly as mentioned in th
 - Exception: If an official alert includes exact clock times, reproduce those times verbatim (and attribute them to the alert).
 
 #OUTPUT
-Describe the most likely conditions and also mention important alternative outcomes using natural language of likelihood or risk. Never imply spatial variation (e.g., do not say "in places").
+Describe the most likely conditions and, only when they are clearly supported by the supplied data and materially useful to the reader, important alternative outcomes. Express uncertainty with natural language such as "likely", "could", or "a risk of"; omit isolated possibilities. An estimated probability shown in the supplied RANGE SUMMARY is a valid estimate and may be used exactly when useful; do not invent a different percentage or a number of scenarios. Never imply spatial variation (e.g., do not say "in places").
 - For winds, use direction words (e.g., "southwesterlies") rather than compass abbreviations, and include a speed range in the required units.
 - If hourly lines include ccNN (total cloud cover percent), use it only as a broad sky-cover cue (clear/partly/mostly/overcast). Do not infer low cloud or fog from ccNN alone unless the weather code already indicates it.
 - If the hourly lines include parenthetical snow-level notes (e.g., "(snow down to about 6500 ft)"), you MUST mention snow levels in the daily forecast. Describe snow on higher terrain/mountains/hills above that elevation, and only mention low-elevation snow when levels are low enough for it.
@@ -70,7 +70,7 @@ Describe the most likely conditions and also mention important alternative outco
 #RANGE SUMMARY
 - Always use the RANGE SUMMARY information when stating low/high temperatures and any precipitation or snowfall ranges it provides.
 - ALWAYS refer to temperatures as **low** and **high**; never use the plural words "highs" or "lows".
-- When a low/high range is provided in the RANGE SUMMARY, ALWAYS include both endpoints in the forecast (e.g., "low 15 to 18°C"); do not collapse to a single value.
+- Use low/high temperatures exactly as summarized: if the RANGE SUMMARY gives one value, report one value; if it gives a range, include both endpoints (e.g., "low 15°C to 18°C").
 - When reporting temperature ranges, repeat the unit after both endpoints (e.g., "-1°C to 10°C").
 - When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
@@ -197,6 +197,8 @@ You will receive forecast datasets for several locations inside the target area.
 - If the datasets include ccNN (total cloud cover percent), use it only as a broad sky-cover cue (clear/partly/mostly/overcast). Do not infer low cloud or fog from ccNN alone unless the weather code already indicates it.
 - If the location datasets include snow-level notes (e.g., "(snow down to about 6500 ft)"), include them. Describe snow on higher terrain/mountains/hills above that elevation and avoid implying widespread lowland snow when levels are high.
 - Discuss uncertainty or alternative outcomes using natural phrasing like "risk of" or "could".
+- Never mention models, scenarios, members, runs, ensembles, or the forecasting process in the reader-facing forecast.
+- An estimated probability shown in a supplied RANGE SUMMARY is valid and may be used exactly when useful; do not invent a different percentage or scenario count.
 - When alerts are provided, include each one prominently in the relevant day's text, citing the official source name and alert title while summarizing timing and hazard details.
 - Only include alerts if provided; never state that no alerts exist.
 - Do not add sentences that merely say impacts will not happen; focus on actual hazards, meaningful risks, and relevant confidence notes.
@@ -286,6 +288,8 @@ You are an expert regional meteorologist. Use the supplied representative locati
 - For each day, start with the bolded date/day string exactly as provided (e.g., "**MONDAY 12 AUGUST:**"). Do NOT add extra day headers beyond the days in the data.
 - After the day header, write one paragraph per sub-region. Begin each paragraph with the bolded region name followed by a colon (e.g., "**South West England:** ...").
 - Describe weather, wind (with speed range), precipitation timing and any explicitly provided amounts, and temperature low/high for each region using the required units. Use natural language to discuss uncertainty ("risk of", "could", "may").
+- Never mention models, scenarios, members, runs, ensembles, or the forecasting process in the reader-facing forecast.
+- An estimated probability shown in a supplied RANGE SUMMARY is valid and may be used exactly when useful; do not invent a different percentage or scenario count.
 - For ensemble ranges, always include both endpoints for low/high temperatures (e.g., "low 15 to 18°C"); do not collapse to a single value.
 - When reporting temperature ranges, repeat the unit after both endpoints (e.g., "-1°C to 10°C").
 - Vary the wording of the low/high temperature sentence across days; for ranges, keep both endpoints while varying phrasing.
@@ -508,6 +512,7 @@ def build_spot_user_prompt(
     impact_instruction: Optional[str] = "",
     impact_context: Optional[str] = "",
     user_extra_context: Optional[str] = "",
+    model_kind: str = "ensemble",
 ) -> str:
     """Build the user prompt sent alongside the dataset for a single location."""
     detail_map = {
@@ -518,6 +523,17 @@ def build_spot_user_prompt(
 
     instructions = "\n".join(filter(None, [short_period_instruction or "", impact_instruction or ""]))
     context_block = _build_context_block(user_extra_context, impact_context)
+    ensemble_rules = ""
+    if (model_kind or "ensemble") == "ensemble":
+        ensemble_rules = """
+--- FINAL ENSEMBLE RULES ---
+- The alternative blocks are possible outcomes for this one location, never different places.
+- Never use spatial wording such as "in some areas", "in places", "elsewhere", or "locally" for differences between them.
+- Mention an alternative only when it is clearly supported by the input and could matter to the reader. Use words such as "likely", "could", or "a risk of"; any estimated probability in the RANGE SUMMARY is valid and may be used exactly when helpful, but do not invent other percentages or scenario counts.
+- Do not mention scenarios, members, models, runs, ensembles, or the forecasting process in the forecast.
+- Use low/high temperatures exactly as supplied in the RANGE SUMMARY: one number when it gives one number, or both endpoints when it gives a range.
+- Use every supplied Date block once as its own forecast period; do not add, merge, or skip periods. A "Rest of..." block is a partial period, so describe only its remaining hours.
+"""
 
     return f"""Write a weather forecast in a friendly and authoritative style, based only on the following information. Write only the forecast, not your instructions.
 
@@ -530,6 +546,7 @@ Detail level: {prompt_detail}
 Location: {location_name} at latitude {latitude:.4f} and longitude {longitude:.4f}
 Season: {season}
 {context_block}
+{ensemble_rules}
 """
 
 

--- a/src/ibf/pipeline/executor.py
+++ b/src/ibf/pipeline/executor.py
@@ -769,6 +769,7 @@ def _generate_location_text_with_adaptive_thinning(
             impact_instruction=impact_instr if ibf_context else "",
             impact_context=ibf_context or "",
             user_extra_context=location.extra_context,
+            model_kind=payload.model_kind,
         )
         if attempt_index:
             logger.warning(

--- a/src/ibf/util/meteo.py
+++ b/src/ibf/util/meteo.py
@@ -37,8 +37,10 @@ _WMO_CODES = {
     85: "light snow showers",
     86: "heavy snow showers",
     95: "thunderstorm",
-    96: "thunderstorm with slight hail",
-    99: "thunderstorm with heavy hail",
+    # Open-Meteo also derives these codes from thunderstorm strength without
+    # hail-specific input, so the codes alone are not enough to forecast hail.
+    96: "strong thunderstorm",
+    99: "severe thunderstorm",
 }
 
 

--- a/tests/test_ensemble_prompt_rules.py
+++ b/tests/test_ensemble_prompt_rules.py
@@ -1,0 +1,67 @@
+from ibf.llm.prompts import (
+    UnitInstructions,
+    build_area_system_prompt,
+    build_regional_system_prompt,
+    build_spot_system_prompt,
+    build_spot_user_prompt,
+)
+
+
+_UNITS = UnitInstructions(
+    temperature_primary="celsius",
+    temperature_secondary=None,
+    precipitation_primary="mm",
+    precipitation_secondary=None,
+    snowfall_primary="cm",
+    snowfall_secondary=None,
+    windspeed_primary="kph",
+    windspeed_secondary=None,
+)
+
+
+def test_ensemble_spot_prompt_keeps_scenarios_internal() -> None:
+    system_prompt = build_spot_system_prompt(_UNITS, model_kind="ensemble")
+    user_prompt = build_spot_user_prompt(
+        "Scenario 01: sample data",
+        location_name="Example",
+        latitude=-41.0,
+        longitude=174.0,
+        season="winter",
+        wordiness="brief",
+        model_kind="ensemble",
+    )
+
+    assert "Scenario labels are internal data labels only" in system_prompt
+    assert "different possible futures at that one location" in system_prompt
+    for spatial_phrase in ('"in some areas"', '"in places"', '"elsewhere"', '"locally"'):
+        assert spatial_phrase in system_prompt
+    assert "Mention geography only when it is explicitly supported" in system_prompt
+    assert "An estimated probability shown in the supplied RANGE SUMMARY is a valid estimate" in system_prompt
+    assert "if the RANGE SUMMARY gives one value, report one value" in system_prompt
+    assert "--- FINAL ENSEMBLE RULES ---" in user_prompt
+    assert 'Never use spatial wording such as "in some areas"' in user_prompt
+    assert "Use every supplied Date block once as its own forecast period" in user_prompt
+    assert user_prompt.index("<END>") < user_prompt.index("--- FINAL ENSEMBLE RULES ---")
+
+
+def test_deterministic_spot_prompt_does_not_add_ensemble_tail_rules() -> None:
+    user_prompt = build_spot_user_prompt(
+        "sample data",
+        location_name="Example",
+        latitude=-41.0,
+        longitude=174.0,
+        season="winter",
+        wordiness="brief",
+        model_kind="deterministic",
+    )
+
+    assert "--- FINAL ENSEMBLE RULES ---" not in user_prompt
+
+
+def test_area_and_regional_ensemble_prompts_avoid_process_jargon() -> None:
+    for system_prompt in (
+        build_area_system_prompt(_UNITS, model_kind="ensemble"),
+        build_regional_system_prompt(_UNITS, model_kind="ensemble"),
+    ):
+        assert "Never mention models, scenarios, members, runs, ensembles" in system_prompt
+        assert "An estimated probability shown in a supplied RANGE SUMMARY is valid" in system_prompt

--- a/tests/test_formatter_units.py
+++ b/tests/test_formatter_units.py
@@ -88,6 +88,88 @@ def test_range_summary_collapses_identical_temperature_endpoints() -> None:
     assert "24°C to 24°C" not in summary
 
 
+def test_range_summary_collapses_one_degree_celsius_spans_to_median() -> None:
+    summary = calculate_range_summary(
+        [23.0, 23.4, 23.8, 24.0],
+        [29.0, 29.4, 29.8, 30.0],
+        [],
+        [],
+        "C",
+        "mm",
+        "cm",
+        False,
+        False,
+    )
+
+    assert "Likely low 24°C" in summary
+    assert "Likely high 30°C" in summary
+    assert "23°C to 24°C" not in summary
+
+
+def test_range_summary_collapses_two_degree_fahrenheit_spans_to_median() -> None:
+    summary = calculate_range_summary(
+        [68.0, 69.0, 70.0],
+        [75.0, 76.0, 77.0],
+        [],
+        [],
+        "F",
+        "inch",
+        "inch",
+        False,
+        False,
+    )
+
+    assert "Likely low 69°F" in summary
+    assert "Likely high 76°F" in summary
+    assert "68°F to 70°F" not in summary
+
+
+def test_range_summary_preserves_wider_temperature_spans() -> None:
+    celsius_summary = calculate_range_summary(
+        [23.0, 25.0],
+        [29.0, 32.0],
+        [],
+        [],
+        "C",
+        "mm",
+        "cm",
+        False,
+        False,
+    )
+    fahrenheit_summary = calculate_range_summary(
+        [68.0, 71.0],
+        [75.0, 78.0],
+        [],
+        [],
+        "F",
+        "inch",
+        "inch",
+        False,
+        False,
+    )
+
+    assert "Likely low 23°C to 25°C" in celsius_summary
+    assert "Likely high 29°C to 32°C" in celsius_summary
+    assert "Likely low 68°F to 71°F" in fahrenheit_summary
+    assert "Likely high 75°F to 78°F" in fahrenheit_summary
+
+
+def test_partial_period_range_summary_uses_only_collapsed_low() -> None:
+    summary = calculate_range_summary(
+        [10.0, 11.0],
+        [15.0, 18.0],
+        [],
+        [],
+        "C",
+        "mm",
+        "cm",
+        True,
+        False,
+    )
+
+    assert summary == "Likely low 11°C"
+
+
 def test_range_summary_collapses_rounded_precipitation_and_snowfall_endpoints() -> None:
     summary = calculate_range_summary(
         [10, 11, 12],

--- a/tests/test_meteo.py
+++ b/tests/test_meteo.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ibf.util.meteo import wmo_weather
+
+
+def test_strong_thunderstorm_codes_do_not_claim_hail() -> None:
+    assert wmo_weather(95) == "thunderstorm"
+    assert wmo_weather(96) == "strong thunderstorm"
+    assert wmo_weather(99) == "severe thunderstorm"
+
+    for code in (96, 99):
+        assert "hail" not in wmo_weather(code)

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "ibf"
-version = "0.8.3"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## What changed

- collapse ensemble temperature spreads of up to 1°C or 2°F to the rounded median before prompting
- reinforce that ensemble alternatives are possible futures for one location, not spatial differences
- keep forecasting-process jargon out of reader-facing forecasts while preserving valid precomputed probabilities
- restate the key ensemble and forecast-period rules after the long data block
- describe Open-Meteo weather codes 96 and 99 as strong and severe thunderstorms rather than unsupported hail
- title future automated releases as `IBF X.Y.Z` while retaining `vX.Y.Z` tags
- prepare version 0.8.4 metadata

## Why

This keeps location forecasts natural and easier to read, avoids distracting one- or two-degree ranges, and prevents derived thunderstorm-strength codes from being presented as evidence of hail.

## Validation

- `uv lock --check`
- `uv run pytest` — 117 passed
- `uv build`
- `git diff --check`
- `actionlint .github/workflows/release-macos-arm64.yml`
