### PR TITLE
Release IBF 0.8.6 with cost-aware GPT-5.6 support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - family-names: Gordon
     given-names: Neil
     orcid: "https://orcid.org/0000-0002-7664-9434"
-version: "0.8.4"
+version: "0.8.5"
 date-released: "2026-07-28"
 repository-code: "https://github.com/tehoro/ibf"
 url: "https://github.com/tehoro/ibf"
@@ -35,6 +35,6 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-7664-9434"
   title: "IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts"
   year: 2026
-  version: "0.8.4"
+  version: "0.8.5"
   url: "https://github.com/tehoro/ibf"
   license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ authors:
   - family-names: Gordon
     given-names: Neil
     orcid: "https://orcid.org/0000-0002-7664-9434"
-version: "0.8.5"
-date-released: "2026-07-28"
+version: "0.8.6"
+date-released: "2026-07-31"
 repository-code: "https://github.com/tehoro/ibf"
 url: "https://github.com/tehoro/ibf"
 license: Apache-2.0
@@ -35,6 +35,6 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-7664-9434"
   title: "IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts"
   year: 2026
-  version: "0.8.5"
+  version: "0.8.6"
   url: "https://github.com/tehoro/ibf"
   license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ API Keys (Simple Guidance)
 Minimal setup for most users:
 - GOOGLE_API_KEY (recommended for reliable geocoding and elevation lookups).
 - OPENWEATHERMAP_API_KEY (for official alert feeds in many countries).
-- One model provider: GEMINI_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or LM Studio.
+- OPENAI_API_KEY (used by the default GPT-5.6 Luna forecast and translation paths).
+- GEMINI_API_KEY (used by the default and recommended impact-context path).
 
 Optional:
 - OPENROUTER_API_KEY (if you want access to many models via OpenRouter).
-- OPENAI_API_KEY (if you want to use OpenAI models directly or use OpenAI hosted web search).
+- LM Studio settings when selecting a local forecast or translation model.
 - BRAVE_SEARCH_API_KEY (only for experimental `context_provider = "brave"`).
 - LM_STUDIO_BASE_URL and, if authentication is enabled, LM_STUDIO_API_KEY.
 
@@ -114,8 +115,12 @@ Alert sources:
 
 Impact context note:
 - IBF only fetches impact context when `location_impact_based` / `area_impact_based` are true (default).
-- `context_provider = "llm-search"` with Gemini is the recommended impact-context path. It uses one
-  primary hosted-search request and reuses the result for up to three local days.
+- `context_provider = "llm-search"` with `gemini-3-flash-preview` is the recommended
+  impact-context path. It uses Gemini's Google Search grounding, verifies that grounding metadata
+  was returned, and reuses the result for up to three local days.
+- Direct OpenAI GPT models, including GPT-5.6 Luna, remain valid `llm-search` choices. They use the
+  OpenAI Responses web-search tool and fail closed if a response was not actually searched, but
+  OpenAI's per-search tool fee usually makes them less economical for routine IBF context.
 - `context_provider = "brave"` is retained as an experimental option. It performs multiple Brave
   searches, then pays the selected local or cloud model to synthesise those results.
 - If impact context cannot be obtained, IBF loudly logs the failure and continues without that
@@ -128,37 +133,49 @@ Impact context note:
 
 Recommended LLM choices
 -----------------------
-For a simple cloud setup, the currently recommended and operationally tested model for all three
-LLM uses (context, forecast, and translation) is:
+For a simple cloud setup, IBF recommends:
 
-- `gemini-3-flash-preview`
+- `gpt-5.6-luna` for forecast writing and translation.
+- `gemini-3-flash-preview` for impact-context research with `context_provider = "llm-search"`.
 
-It has produced reliable Google Search-grounded context in IBF testing and remains inexpensive.
-It is a preview model, so monitor Google's
-[deprecation schedule](https://ai.google.dev/gemini-api/docs/deprecations). The stable
-`gemini-3.6-flash` is a supported, more capable but more expensive alternative. Flash-Lite models
-remain useful low-cost choices for forecast writing or translation, but are not the recommended
-context model because they have sometimes returned text without invoking Search.
+Luna's standard token pricing checked on 31 July 2026 is US$0.20 input, US$0.02 cached input, and
+US$1.20 output per million tokens. GPT-5.6 Terra is a more capable alternative at US$2.00,
+US$0.20, and US$12.00 respectively. Luna can also perform grounded context research through the
+OpenAI Responses web-search tool, but OpenAI charges US$10 per 1,000 web-search calls in addition
+to model tokens. See [OpenAI API pricing](https://developers.openai.com/api/docs/pricing).
+
+Gemini 3 Flash Preview costs US$0.50 input and US$3.00 output per million tokens, but paid Gemini
+projects currently receive 5,000 Google Search requests per month shared across Gemini 3.x models
+before US$14 per 1,000 requests applies. At IBF's usual three-day context-cache cadence, that
+included allowance normally outweighs Luna's lower token rates. Google counts each search query
+the model executes, not each IBF context prompt, so high-volume users should compare actual usage.
+This is a preview model and may change or be retired; check
+[Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing) and Google's
+[deprecation schedule](https://ai.google.dev/gemini-api/docs/deprecations) before long-term
+deployment.
 
 Suggested config snippet:
 
 ```toml
-llm = "gemini-3-flash-preview"
+llm = "gpt-5.6-luna"
 context_provider = "llm-search"
 context_llm = "gemini-3-flash-preview"
-translation_llm = "gemini-3-flash-preview"
+translation_llm = "gpt-5.6-luna"
+enable_reasoning = true
+location_reasoning = "high"
+area_reasoning = "high"
 ```
 
 For local forecast writing and translation while retaining recommended Gemini context research:
 
 ```toml
 llm = "lms:exact-loaded-gemma-4-model-id"
-llm_fallback = "gemini-3-flash-preview"
+llm_fallback = "gpt-5.6-luna"
 lm_studio_base_url = "http://192.168.1.50:1234/v1"
 context_provider = "llm-search"
 context_llm = "gemini-3-flash-preview"
 translation_llm = "lms:exact-loaded-gemma-4-model-id"
-translation_llm_fallback = "gemini-3-flash-preview"
+translation_llm_fallback = "gpt-5.6-luna"
 ```
 
 For LM Studio, Gemma 4 is the recommended local model family. Good candidates are Gemma 4 12B
@@ -220,7 +237,7 @@ Minimal example:
 
 ```toml
 web_root = "./outputs/example-site"
-llm = "gemini-3-flash-preview"
+llm = "gpt-5.6-luna"
 context_provider = "llm-search"
 context_llm = "gemini-3-flash-preview"
 
@@ -337,8 +354,8 @@ Environment variables:
 | `GOOGLE_API_KEY` | Geocoding and optional elevation lookup. Also used for reverse geocoding when resolving alert country codes. | Recommended for reliable geocoding/elevation. |
 | `OPENWEATHERMAP_API_KEY` | Alerts (OpenWeatherMap One Call for non‑US/NZ) and fallback reverse geocoding. | Required for non‑US/NZ alerts, otherwise optional. |
 | `OPENROUTER_API_KEY` | Any model name with an `or:` prefix. | Required for OpenRouter usage. |
-| `OPENAI_API_KEY` | OpenAI models such as `gpt-4o-mini` or `gpt-4o-latest`. | Required if using OpenAI models. |
-| `GEMINI_API_KEY` | Direct Gemini SDK usage (`gemini-*` or `google/gemini-*`). | Required if using direct Gemini models. |
+| `OPENAI_API_KEY` | OpenAI models such as the default forecast/translation model `gpt-5.6-luna`. | Required for the recommended cloud setup. |
+| `GEMINI_API_KEY` | Direct Gemini SDK usage (`gemini-*` or `google/gemini-*`), including the default context model. | Required for the recommended cloud setup. |
 | `BRAVE_SEARCH_API_KEY` | Experimental Brave LLM Context evidence retrieval. | Required when `context_provider = "brave"`. |
 | `LM_STUDIO_BASE_URL` | Optional environment alternative to the TOML `lm_studio_base_url`. | Optional; defaults to `http://localhost:1234/v1`. |
 | `LM_STUDIO_API_KEY` | LM Studio API token. | Only required when authentication is enabled on the LM Studio server. |
@@ -368,8 +385,17 @@ OpenWeatherMap API key (alerts)
 3) Ensure the One Call API is enabled for your account (alerts come from One Call).
 4) Paste the key into your .env as `OPENWEATHERMAP_API_KEY=...`.
 
-Gemini API key (Google AI Studio; recommended for impact context)
------------------------------------------------------------------
+OpenAI API key (default forecast and translation LLM)
+-----------------------------------------------------
+
+1) Go to <https://platform.openai.com/api-keys> and sign in.
+2) Create an API key for the project that will run IBF.
+3) Ensure the project has billing and access to the selected GPT model. Access to the web-search
+   tool is also required if you explicitly select a GPT model for impact context.
+4) Paste the key into your `.env` as `OPENAI_API_KEY=...`.
+
+Gemini API key (Google AI Studio; recommended context)
+------------------------------------------------------
 1) Go to <https://aistudio.google.com/> and sign in.
 2) Click "Get API key" and create a new key (choose or create a project if prompted).
 3) Enable billing for the project when using Google Search grounding. Google currently makes
@@ -468,8 +494,8 @@ Global settings:
 | `translation_llm_fallback` | Optional model tried once if translation fails. | May use a different provider. |
 | `translation_language` | Default translation language. | English output is always produced; translations are additional. |
 | `enable_reasoning` | Enable model reasoning when supported. | Boolean; defaults to true. |
-| `location_reasoning` | Reasoning level for location forecasts. | `off`/`minimal`, `low`, `medium`, `high`, or `auto`. |
-| `area_reasoning` | Reasoning level for area forecasts. | Same values as above. |
+| `location_reasoning` | Reasoning level for location forecasts. | `off`/`minimal`, `low`, `medium`, `high`, or `auto`; defaults to `high`. |
+| `area_reasoning` | Reasoning level for area forecasts. | Same values as above; defaults to `high`. |
 | `location_forecast_days` | Days of forecast for locations. | Defaults to 4 when unset. |
 | `area_forecast_days` | Days of forecast for areas. | Defaults to location days or 4. |
 | `location_wordiness` | `brief`, `normal`, or `detailed`. | Default is `normal`. |
@@ -564,12 +590,13 @@ Resolution order (highest to lowest):
 1) Explicit override (e.g., `translation_llm` for translation calls)
 2) `llm` from config
 3) `IBF_DEFAULT_LLM` environment variable
-4) Default fallback (`gemini-3-flash-preview`)
+4) Default fallback (`gpt-5.6-luna`)
 
 Provider naming:
 - LM Studio: `lms:exact-model-id` (uses `lm_studio_base_url`; optional `LM_STUDIO_API_KEY`)
 - OpenRouter: `or:provider/model` (requires `OPENROUTER_API_KEY`)
-- OpenAI: `gpt-4o-mini`, `gpt-4o-latest` (requires `OPENAI_API_KEY`)
+- OpenAI: `gpt-5.6-luna`, `gpt-5.6-terra`, or another `gpt-*`/`o*` model
+  (requires `OPENAI_API_KEY`)
 - Gemini direct: `gemini-3-flash-preview`, `gemini-3.6-flash`, or the equivalent
   `google/gemini-*` form (requires `GEMINI_API_KEY`)
 
@@ -591,10 +618,10 @@ The research provider and the model are separate choices:
 
 | `context_provider` | Retrieval | Allowed `context_llm` | Notes |
 | --- | --- | --- | --- |
-| `llm-search` | Gemini Google Search or OpenAI web search tool | Direct Gemini or OpenAI | **Recommended.** One primary context job is reused for up to three local days; the hosted provider decides its searches. |
+| `llm-search` | Gemini Google Search or OpenAI web search tool | Direct Gemini or OpenAI | **Recommended with `gemini-3-flash-preview`.** One primary context job is reused for up to three local days; the hosted provider decides its searches. |
 | `brave` | IBF-controlled Brave LLM Context requests | LM Studio, OpenRouter, Gemini, or OpenAI | **Experimental.** Brave returns evidence and the separately selected model synthesises it, adding cost and complexity. |
 
-The recommended Gemini hosted-search path:
+The recommended hosted-search path:
 
 - Supplies the canonical geocoded locality, district/region, country and representative places so
   near-name results from another place are not silently substituted.
@@ -648,26 +675,38 @@ The experimental Brave provider is staged and bounded:
 
 `context_fallback_llm` is intentionally different from a synthesis-model fallback. If the Brave
 path fails, it makes one attempt through the existing hosted-search path, so it must name a direct
-Gemini or OpenAI model. Leave it unset to fail closed and continue the forecast without researched
-context.
+Gemini or OpenAI model. `gemini-3-flash-preview` is recommended for this fallback for the same
+grounding-cost reason as the normal hosted-search path. Leave it unset to fail closed and continue
+the forecast without researched context.
 
 Reasoning levels (forecast text):
-- OpenAI reasoning models (direct or via OpenRouter) use `reasoning.effort` with `low`/`medium`/`high`; `minimal` maps to `low`, and `off` disables the reasoning payload.
+- Direct GPT-5 OpenAI Chat Completions calls use `reasoning_effort`; OpenRouter uses
+  `reasoning.effort`. `minimal` maps to `low`, and `off` disables the reasoning payload.
 - OpenRouter supports reasoning for select models (currently OpenAI o1/o3/GPT-5 and Grok). Other OpenRouter models ignore the reasoning settings.
 - Current Gemini 3 models use `thinkingLevel` with `minimal`/`low`/`medium`/`high`; `off` maps to `minimal` (Gemini does not fully disable thinking).
 - `auto` lets the provider choose its default (dynamic) behavior.
+- `enable_reasoning` is the master switch. When it is true and no location/area level is supplied,
+  IBF uses `high`; the two separate level fields remain available for explicit tuning.
 
 LLM cost overrides (optional):
 - OpenRouter's provider-reported `usage.cost` is used when returned by a completed request.
 - Direct providers that return tokens but not a monetary cost use the current built-in price table;
   Gemini thinking tokens are included at the model's output-token rate.
+- GPT-5.6 Luna is estimated at US$0.20 input / US$0.02 cached input / US$1.20 output
+  per million tokens; Terra is US$2.00 / US$0.20 / US$12.00.
+- OpenAI web search costs US$10 per 1,000 calls plus search-content tokens at the model rate.
+  These tool fees are separate from model-token charges and are not currently included in IBF's
+  token-based cost summary.
 - LM Studio is treated as unpriced unless its exact model identifier has an entry in
   `llm_costs.toml`.
 - Brave request cost is a list-price estimate because its response does not return a per-request
   monetary amount. At the price checked for 0.8.0, each new request is estimated at 0.5 US cents.
-- Gemini's API reports token usage but not the final monetary effect of its monthly grounding
-  allowance or any later Google Search tool charges. IBF records the returned search-query count
-  privately, but the cost summary can only estimate the model-token portion.
+- Paid Gemini projects currently include 5,000 Google Search requests per month, shared across all
+  Gemini 3.x models, then charge US$14 per 1,000 requests. Gemini may execute more than one search
+  query for a single IBF context prompt.
+- Gemini's API reports token usage but not the final monetary effect of that monthly grounding
+  allowance or later Google Search charges. IBF records the returned search-query count privately,
+  but the cost summary can only estimate the model-token portion.
 - In a representative run using `gemini-3-flash-preview`, eight distinct context jobs cost about
   2.7 US cents in model tokens. At a three-day refresh cadence, 20 entities would be roughly
   US$0.60–0.70 per month while Search remains within Google's included grounding allowance.
@@ -675,10 +714,10 @@ LLM cost overrides (optional):
 - Costs are USD per million tokens:
   ```toml
   [[model]]
-  name = "gemini-3-flash-preview"
-  input = 0.50
-  cached_input = 0.05
-  output = 3.00
+  name = "gpt-5.6-luna"
+  input = 0.20
+  cached_input = 0.02
+  output = 1.20
   ```
 
 Cache behavior (technical)

--- a/config_examples/config--example-cmo.toml
+++ b/config_examples/config--example-cmo.toml
@@ -1,10 +1,10 @@
 # Sample Configuration for Caribbean Meteorological Organisation
 
 # Language Models to use
-llm = "gemini-3-flash-preview"
+llm = "gpt-5.6-luna"
 context_provider = "llm-search"  # recommended; Brave is experimental
-context_llm = "gemini-3-flash-preview"
-translation_llm = "gemini-3-flash-preview"
+context_llm = "gemini-3-flash-preview"  # recommended hosted-search model
+translation_llm = "gpt-5.6-luna"
 # Recommended local family: Gemma 4. Copy its exact ID and set lm_studio_base_url.
 # Optional fallbacks: llm_fallback, translation_llm_fallback, context_fallback_llm.
 enable_reasoning = true   # use reasoning or thinking where supported
@@ -16,14 +16,14 @@ model = "ens:ecmwf_ifs025"
 # Location specific settings
 location_forecast_days = 4
 location_wordiness = "normal"
-location_reasoning = "low"
+location_reasoning = "high"
 location_impact_based = true
 location_thin_select = 10   # thin ensemble members down to a representative 10
 
 # Area specific settings
 area_forecast_days = 2
 area_wordiness = "brief"
-area_reasoning = "low"
+area_reasoning = "high"
 area_impact_based = true
 area_thin_select = 10
 

--- a/config_examples/config-example-snow.toml
+++ b/config_examples/config-example-snow.toml
@@ -1,10 +1,10 @@
 # Sample Configration To Test Snow Levels
 
 # Language Models to use
-llm = "gemini-3-flash-preview"
+llm = "gpt-5.6-luna"
 context_provider = "llm-search"  # recommended; Brave is experimental
-context_llm = "gemini-3-flash-preview"
-translation_llm = "gemini-3-flash-preview"
+context_llm = "gemini-3-flash-preview"  # recommended hosted-search model
+translation_llm = "gpt-5.6-luna"
 # Recommended local family: Gemma 4. Copy its exact ID and set lm_studio_base_url.
 # Optional fallbacks: llm_fallback, translation_llm_fallback, context_fallback_llm.
 enable_reasoning = true   # use reasoning or thjnking where supported
@@ -16,14 +16,14 @@ model = "det:open-meteo"
 # Location specific settings
 location_forecast_days = 4
 location_wordiness = "normal"
-location_reasoning = "low"
+location_reasoning = "high"
 location_impact_based = true
 location_thin_select = 10   # thin ensemble members down to a representative 10
 
 # Area specific settings
 area_forecast_days = 2
 area_wordiness = "brief"
-area_reasoning = "low"
+area_reasoning = "high"
 area_impact_based = true
 area_thin_select = 10
 

--- a/config_examples/config-example.toml
+++ b/config_examples/config-example.toml
@@ -1,10 +1,10 @@
 # Sample Configration Showing Different Options
 
 # Language Models to use
-llm = "gemini-3-flash-preview"
+llm = "gpt-5.6-luna"
 # Recommended local family: Gemma 4; copy the exact loaded model ID from LM Studio.
 # llm = "lms:exact-loaded-gemma-4-model-id"  # local or network LM Studio
-# llm_fallback = "gemini-3-flash-preview"     # optional one-step fallback
+# llm_fallback = "gemini-3-flash-preview"     # optional one-step cross-provider fallback
 # lm_studio_base_url = "http://192.168.1.50:1234/v1"
 
 # Recommended: Gemini hosted web search, cached for up to three local days.
@@ -12,7 +12,7 @@ llm = "gemini-3-flash-preview"
 context_provider = "llm-search"
 context_llm = "gemini-3-flash-preview"
 # context_fallback_llm = "gemini-3-flash-preview"  # experimental Brave -> hosted fallback
-translation_llm = "gemini-3-flash-preview"
+translation_llm = "gpt-5.6-luna"
 # translation_llm_fallback = "gpt-4o-mini"
 enable_reasoning = true   # use reasoning or thinking where supported
 
@@ -23,14 +23,14 @@ model = "ens:ecmwf_ifs025"
 # Location specific settings
 location_forecast_days = 4
 location_wordiness = "normal"
-location_reasoning = "low"
+location_reasoning = "high"
 location_impact_based = true
 location_thin_select = 10   # thin ensemble members down to a representative 10
 
 # Area specific settings
 area_forecast_days = 2
 area_wordiness = "brief"
-area_reasoning = "low"
+area_reasoning = "high"
 area_impact_based = true
 area_thin_select = 10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibf"
-version = "0.8.5"
+version = "0.8.6"
 description = "Unified impact-based forecast CLI and service"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibf"
-version = "0.8.4"
+version = "0.8.5"
 description = "Unified impact-based forecast CLI and service"
 readme = "README.md"
 authors = [

--- a/src/ibf/__init__.py
+++ b/src/ibf/__init__.py
@@ -4,7 +4,7 @@ Core package for the unified Impact-Based Forecast tooling.
 
 from importlib import metadata as _metadata
 
-_EMBEDDED_VERSION = "0.8.4"
+_EMBEDDED_VERSION = "0.8.5"
 
 
 def _resolve_version() -> str:

--- a/src/ibf/__init__.py
+++ b/src/ibf/__init__.py
@@ -4,7 +4,7 @@ Core package for the unified Impact-Based Forecast tooling.
 
 from importlib import metadata as _metadata
 
-_EMBEDDED_VERSION = "0.8.5"
+_EMBEDDED_VERSION = "0.8.6"
 
 
 def _resolve_version() -> str:

--- a/src/ibf/api/impact.py
+++ b/src/ibf/api/impact.py
@@ -36,9 +36,9 @@ MAX_CONTEXT_AGE_DAYS = 3
 EVENT_LOOKAHEAD_DAYS = 10
 HOSTED_RESEARCH_VERSION = 2
 DEFAULT_CONTEXT_LLM = "gemini-3-flash-preview"
-# Before 0.8, this model's cache filenames omitted the model suffix. Preserve
-# that convention now that the proven model is again the recommended default.
-LEGACY_UNSUFFIXED_CONTEXT_LLM = "gemini-3-flash-preview"
+# Before 0.8, the default context model's cache filenames omitted the model
+# suffix. Preserve that convention so existing Gemini context remains reusable.
+LEGACY_UNSUFFIXED_CONTEXT_LLM = DEFAULT_CONTEXT_LLM
 CONTEXT_SECTION_HEADINGS = [
     "Existing Vulnerabilities",
     "Weather Impact Thresholds",
@@ -1325,6 +1325,13 @@ def _generate_context_openai_web_search(
             label="Impact context LLM usage",
             provider="openai",
         )
+        if not _openai_response_used_web_search(response):
+            logger.error(
+                "OpenAI returned impact context for %s without a web_search_call; "
+                "discarding the ungrounded response.",
+                name,
+            )
+            return "", cost_cents
         context_text = _extract_response_text(response)
         return context_text, cost_cents
     except (OpenAIError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
@@ -1335,6 +1342,15 @@ def _generate_context_openai_web_search(
             exc,
         )
         return "", 0.0
+
+
+def _openai_response_used_web_search(response: Any) -> bool:
+    """Return True only when a Responses result records an actual web search call."""
+    for item in getattr(response, "output", None) or []:
+        item_type = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+        if item_type == "web_search_call":
+            return True
+    return False
 
 
 def _generate_context_gemini_search(

--- a/src/ibf/config/models.py
+++ b/src/ibf/config/models.py
@@ -92,7 +92,7 @@ class ForecastConfig(BaseModel):
         area_impact_based: Enable impact-based context for areas.
         location_thin_select: Number of ensemble members to select for locations.
         area_thin_select: Number of ensemble members to select for areas.
-        llm: LLM model identifier (e.g., "gemini-3-flash-preview").
+        llm: LLM model identifier (e.g., "gpt-5.6-luna").
         llm_fallback: Optional model used when the primary forecast model fails.
         lm_studio_base_url: Optional LM Studio server URL for ``lms:`` models.
         context_provider: Impact-context research provider (recommended ``llm-search`` or
@@ -113,8 +113,8 @@ class ForecastConfig(BaseModel):
     location_wordiness: Optional[str] = None
     area_wordiness: Optional[str] = None
     enable_reasoning: bool = True
-    location_reasoning: Optional[str] = None
-    area_reasoning: Optional[str] = None
+    location_reasoning: Optional[str] = "high"
+    area_reasoning: Optional[str] = "high"
     location_impact_based: bool = True
     area_impact_based: bool = True
     location_thin_select: Optional[int] = None

--- a/src/ibf/llm/__init__.py
+++ b/src/ibf/llm/__init__.py
@@ -2,7 +2,7 @@
 LLM utilities: prompt generation, formatting, and client wrappers.
 """
 
-from .settings import LLMSettings, resolve_llm_settings
+from .settings import DEFAULT_LLM, LLMSettings, resolve_llm_settings
 from .client import generate_forecast_text, consume_last_cost_cents
 from .formatter import (
     format_location_dataset,
@@ -22,6 +22,7 @@ from .prompts import (
 
 __all__ = [
     "LLMSettings",
+    "DEFAULT_LLM",
     "resolve_llm_settings",
     "generate_forecast_text",
     "consume_last_cost_cents",
@@ -37,4 +38,3 @@ __all__ = [
     "build_translation_system_prompt",
     "build_translation_user_prompt",
 ]
-

--- a/src/ibf/llm/client.py
+++ b/src/ibf/llm/client.py
@@ -81,17 +81,25 @@ def _call_openai_compatible(
     if settings.timeout_seconds is not None:
         client_kwargs["timeout"] = settings.timeout_seconds
     client = OpenAI(**client_kwargs)
-    request_kwargs = {
+    request_kwargs: dict[str, Any] = {
         "model": settings.model,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": prompt},
         ],
-        "temperature": settings.temperature,
-        "max_tokens": settings.max_tokens,
         "stream": False,
     }
-    if reasoning:
+    if settings.provider == "openai" and _uses_gpt5_chat_parameters(settings.model):
+        request_kwargs["max_completion_tokens"] = settings.max_tokens
+        effort = _reasoning_effort(reasoning)
+        if effort:
+            request_kwargs["reasoning_effort"] = effort
+    else:
+        request_kwargs["temperature"] = settings.temperature
+        request_kwargs["max_tokens"] = settings.max_tokens
+    if reasoning and not (
+        settings.provider == "openai" and _uses_gpt5_chat_parameters(settings.model)
+    ):
         request_kwargs["extra_body"] = reasoning
     response = client.chat.completions.create(**request_kwargs)
     cost_cents = log_openai_usage_and_cost(
@@ -136,6 +144,22 @@ def _call_openai_compatible(
             getattr(choice, "finish_reason", None),
         )
     return cleaned
+
+
+def _uses_gpt5_chat_parameters(model_name: str) -> bool:
+    """Return whether direct OpenAI Chat Completions needs GPT-5 parameters."""
+    return (model_name or "").strip().lower().startswith("gpt-5")
+
+
+def _reasoning_effort(reasoning: Optional[dict]) -> Optional[str]:
+    """Extract an effort value from IBF's provider-neutral reasoning payload."""
+    if not reasoning:
+        return None
+    nested = reasoning.get("reasoning")
+    if not isinstance(nested, dict):
+        return None
+    effort = nested.get("effort")
+    return str(effort) if effort else None
 
 
 @lru_cache(maxsize=32)

--- a/src/ibf/llm/costs.py
+++ b/src/ibf/llm/costs.py
@@ -60,7 +60,7 @@ class ModelCost:
 
 # NOTE: Keep this mapping simple so users can edit it without digging through code.
 MODEL_COSTS: Dict[str, ModelCost] = {
-    # Pricing checked 27 July 2026 against official provider pricing pages.
+    # Pricing checked 31 July 2026 against official provider pricing pages.
     "gpt-4o-mini": ModelCost(
         input_per_million=0.15,
         cached_input_per_million=0.075,
@@ -85,6 +85,16 @@ MODEL_COSTS: Dict[str, ModelCost] = {
         input_per_million=0.25,
         cached_input_per_million=0.025,
         output_per_million=2.00,
+    ),
+    "gpt-5.6-luna": ModelCost(
+        input_per_million=0.20,
+        cached_input_per_million=0.02,
+        output_per_million=1.20,
+    ),
+    "gpt-5.6-terra": ModelCost(
+        input_per_million=2.00,
+        cached_input_per_million=0.20,
+        output_per_million=12.00,
     ),
     "gemini-2.5-flash": ModelCost(
         input_per_million=0.30,

--- a/src/ibf/llm/prompts.py
+++ b/src/ibf/llm/prompts.py
@@ -68,9 +68,10 @@ Describe the most likely conditions and, only when they are clearly supported by
 - If the hourly lines include parenthetical snow-level notes (e.g., "(snow down to about 6500 ft)"), you MUST mention snow levels in the daily forecast. Describe snow on higher terrain/mountains/hills above that elevation, and only mention low-elevation snow when levels are low enough for it.
 
 #RANGE SUMMARY
-- Always use the RANGE SUMMARY information when stating low/high temperatures and any precipitation or snowfall ranges it provides.
+- Treat each day's RANGE SUMMARY as the authoritative source for daily low/high temperatures and precipitation or snowfall amounts. Never substitute or recalculate these figures from Scenario blocks or hourly lines.
 - ALWAYS refer to temperatures as **low** and **high**; never use the plural words "highs" or "lows".
-- Use low/high temperatures exactly as summarized: if the RANGE SUMMARY gives one value, report one value; if it gives a range, include both endpoints (e.g., "low 15°C to 18°C").
+- Use low/high temperatures exactly as summarized: if the RANGE SUMMARY gives one value, report exactly that one value with no adjacent alternative; if it gives a range, include both endpoints (e.g., "low 15°C to 18°C"). The alternative-outcome rules do not apply to daily low/high figures.
+- Whenever rain or snow is mentioned and the RANGE SUMMARY supplies an amount or range, include that exact amount or both range endpoints. Never omit it, substitute an individual Scenario total, or calculate a different amount.
 - When reporting temperature ranges, repeat the unit after both endpoints (e.g., "-1°C to 10°C").
 - When the lower end of a rainfall or snowfall range is 0 but the upper end is greater than 0, express it as "up to X [unit]" rather than "0 to X [unit]". Never write "up to 0 [unit]"; if an upper amount rounds to 0, omit the amount.
 - When reporting snowfall in cm, round to the nearest whole cm in the narrative; if the rounded low and high are the same, say "around X cm".
@@ -531,7 +532,9 @@ def build_spot_user_prompt(
 - Never use spatial wording such as "in some areas", "in places", "elsewhere", or "locally" for differences between them.
 - Mention an alternative only when it is clearly supported by the input and could matter to the reader. Use words such as "likely", "could", or "a risk of"; any estimated probability in the RANGE SUMMARY is valid and may be used exactly when helpful, but do not invent other percentages or scenario counts.
 - Do not mention scenarios, members, models, runs, ensembles, or the forecasting process in the forecast.
-- Use low/high temperatures exactly as supplied in the RANGE SUMMARY: one number when it gives one number, or both endpoints when it gives a range.
+- For daily low/high temperatures and precipitation or snowfall amounts, the RANGE SUMMARY overrides all alternative-block and hourly values. Do not recalculate or widen its figures.
+- A single summarized low or high is final: report exactly that one value, never "X or Y", "X to Y", or an adjacent alternative. For example, "Likely high 12°C" means "high near 12°C", never "12°C or 13°C".
+- Whenever rain or snow is mentioned and the RANGE SUMMARY supplies an amount or range, you MUST include that exact amount or both endpoints. Never omit it or substitute an alternative-block total. For example, "Likely precipitation 33 mm to 50 mm" must be reported as "33 mm to 50 mm".
 - Use every supplied Date block once as its own forecast period; do not add, merge, or skip periods. A "Rest of..." block is a partial period, so describe only its remaining hours.
 """
 

--- a/src/ibf/llm/settings.py
+++ b/src/ibf/llm/settings.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 from ..config import ForecastConfig
 
+DEFAULT_LLM = "gpt-5.6-luna"
+
 
 @dataclass
 class LLMSettings:
@@ -41,7 +43,7 @@ def resolve_llm_settings(config: ForecastConfig, override_choice: Optional[str] 
     Inspect the forecast config and environment variables to determine which LLM to use.
 
     Prioritizes `override_choice`, then `config.llm`, then `IBF_DEFAULT_LLM` env var,
-    and finally defaults to the recommended direct Gemini model.
+    and finally defaults to the recommended direct OpenAI model.
 
     Args:
         config: The forecast configuration.
@@ -57,7 +59,7 @@ def resolve_llm_settings(config: ForecastConfig, override_choice: Optional[str] 
         override_choice
         or config.llm
         or os.environ.get("IBF_DEFAULT_LLM")
-        or "gemini-3-flash-preview"
+        or DEFAULT_LLM
     )
     choice = base_choice.strip()
     choice_lower = choice.lower()

--- a/src/ibf/pipeline/executor.py
+++ b/src/ibf/pipeline/executor.py
@@ -35,6 +35,7 @@ from ..api import (
     ImpactContext,
     resolve_model_spec,
 )
+from ..api.impact import DEFAULT_CONTEXT_LLM
 from ..api.thin import select_members
 from ..render import ForecastPage, render_forecast_page
 from ..util import ensure_directory, safe_unlink, slugify, utc_now, write_text_file
@@ -175,15 +176,15 @@ def _log_cost_summary() -> None:
         total_forecast += entry.forecast_cents
         total_translation += entry.translation_cents
         lines.append(
-            f"{_format_label(label, label_width)} {entry.context_cents:>12.1f} {entry.forecast_cents:>12.1f} {entry.translation_cents:>12.1f}"
+            f"{_format_label(label, label_width)} {entry.context_cents:>12.2f} {entry.forecast_cents:>12.2f} {entry.translation_cents:>12.2f}"
         )
 
     lines.append("-" * len(header))
     lines.append(
-        f"{'TOTAL':<{label_width}} {total_context:>12.1f} {total_forecast:>12.1f} {total_translation:>12.1f}"
+        f"{'TOTAL':<{label_width}} {total_context:>12.2f} {total_forecast:>12.2f} {total_translation:>12.2f}"
     )
     grand_total = total_context + total_forecast + total_translation
-    lines.append(f"{'Grand total':<{label_width}} {grand_total:>12.1f}")
+    lines.append(f"{'Grand total':<{label_width}} {grand_total:>12.2f}")
 
     logger.info("LLM cost summary (USD cents):\n%s", "\n".join(lines))
 
@@ -326,7 +327,7 @@ def _process_location(location: LocationConfig, config: ForecastConfig, display_
     ibf_context = ""
     impact_context = None
     if impact_enabled:
-        context_llm = (getattr(config, "context_llm", None) or "gemini-3-flash-preview").strip()
+        context_llm = (getattr(config, "context_llm", None) or DEFAULT_CONTEXT_LLM).strip()
         impact_context = fetch_impact_context(
             name,
             context_type="location",
@@ -467,7 +468,7 @@ def _process_area(area: AreaConfig, config: ForecastConfig) -> None:
     ibf_context = ""
     impact_context = None
     if impact_enabled:
-        context_llm = (getattr(config, "context_llm", None) or "gemini-3-flash-preview").strip()
+        context_llm = (getattr(config, "context_llm", None) or DEFAULT_CONTEXT_LLM).strip()
         impact_context = fetch_impact_context(
             area.name,
             context_type="area",
@@ -615,7 +616,7 @@ def _process_regional_area(area: AreaConfig, config: ForecastConfig) -> None:
     ibf_context = ""
     impact_context = None
     if impact_enabled:
-        context_llm = (getattr(config, "context_llm", None) or "gemini-3-flash-preview").strip()
+        context_llm = (getattr(config, "context_llm", None) or DEFAULT_CONTEXT_LLM).strip()
         impact_context = fetch_impact_context(
             area.name,
             context_type="regional",
@@ -2260,7 +2261,7 @@ def _reasoning_payload(enabled: bool, level: Optional[str]) -> Optional[dict]:
     effort, max_tokens, disable_override = _parse_reasoning_setting(level)
     if disable_override:
         return None
-    resolved_effort = "low" if effort == "minimal" else (effort or "medium")
+    resolved_effort = "low" if effort == "minimal" else (effort or "high")
     payload: dict[str, object] = {"reasoning": {"effort": resolved_effort}}
     if max_tokens:
         payload["max_output_tokens"] = max_tokens
@@ -2312,8 +2313,10 @@ def _gemini_thinking_level(enabled: bool, level: Optional[str]) -> Optional[str]
     effort, _, disable_override = _parse_reasoning_setting(level)
     if not enabled or disable_override:
         return "minimal"
-    if not effort or effort == "auto":
+    if effort == "auto":
         return None
+    if not effort:
+        return "high"
     if effort in {"minimal", "low", "medium", "high"}:
         return effort
     return None

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -65,6 +65,66 @@ def test_rejects_openrouter_context_llm(tmp_path: Path) -> None:
     assert "context_llm" in str(exc.value)
 
 
+@pytest.mark.parametrize("context_llm", ["gpt-5.6-luna", "gpt-5.6-terra"])
+def test_llm_search_accepts_openai_gpt_context_models(
+    tmp_path: Path,
+    context_llm: str,
+) -> None:
+    path = _write_config(
+        tmp_path,
+        f'''\
+        context_provider = "llm-search"
+        context_llm = "{context_llm}"
+
+        [[location]]
+        name = "Test City"
+        ''',
+    )
+
+    config = load_config(path)
+
+    assert config.context_provider == "llm-search"
+    assert config.context_llm == context_llm
+
+
+def test_reasoning_defaults_to_high_with_separate_master_switch(tmp_path: Path) -> None:
+    config = load_config(
+        _write_config(
+            tmp_path,
+            """
+            enable_reasoning = true
+
+            [[location]]
+            name = "Test City"
+            """,
+        )
+    )
+
+    assert config.enable_reasoning is True
+    assert config.location_reasoning == "high"
+    assert config.area_reasoning == "high"
+
+
+def test_explicit_legacy_reasoning_levels_are_preserved(tmp_path: Path) -> None:
+    config = load_config(
+        _write_config(
+            tmp_path,
+            """
+            enable_reasoning = false
+            location_reasoning = "low"
+            area_reasoning = "auto"
+
+            [[location]]
+            name = "Test City"
+            """,
+        )
+    )
+
+    assert config.enable_reasoning is False
+    assert config.location_reasoning == "low"
+    assert config.area_reasoning == "auto"
+
+
 @pytest.mark.parametrize("context_llm", ["or:openai/gpt-5-mini", "lms:local-context"])
 def test_brave_context_accepts_any_supported_synthesis_model(
     tmp_path: Path,

--- a/tests/test_ensemble_prompt_rules.py
+++ b/tests/test_ensemble_prompt_rules.py
@@ -37,9 +37,15 @@ def test_ensemble_spot_prompt_keeps_scenarios_internal() -> None:
         assert spatial_phrase in system_prompt
     assert "Mention geography only when it is explicitly supported" in system_prompt
     assert "An estimated probability shown in the supplied RANGE SUMMARY is a valid estimate" in system_prompt
-    assert "if the RANGE SUMMARY gives one value, report one value" in system_prompt
+    assert "RANGE SUMMARY as the authoritative source" in system_prompt
+    assert "report exactly that one value with no adjacent alternative" in system_prompt
+    assert "Whenever rain or snow is mentioned" in system_prompt
     assert "--- FINAL ENSEMBLE RULES ---" in user_prompt
     assert 'Never use spatial wording such as "in some areas"' in user_prompt
+    assert "the RANGE SUMMARY overrides all alternative-block and hourly values" in user_prompt
+    assert 'never "12°C or 13°C"' in user_prompt
+    assert "you MUST include that exact amount or both endpoints" in user_prompt
+    assert '"33 mm to 50 mm"' in user_prompt
     assert "Use every supplied Date block once as its own forecast period" in user_prompt
     assert user_prompt.index("<END>") < user_prompt.index("--- FINAL ENSEMBLE RULES ---")
 

--- a/tests/test_impact_context.py
+++ b/tests/test_impact_context.py
@@ -376,6 +376,56 @@ def test_openai_web_search_failure_does_not_use_ungrounded_chat(monkeypatch) -> 
     assert cost == 0.0
 
 
+def test_luna_context_uses_responses_web_search(monkeypatch) -> None:
+    captured = {}
+    response = SimpleNamespace(
+        output_text=_valid_synthesis(),
+        output=[SimpleNamespace(type="web_search_call", status="completed")],
+        usage=None,
+    )
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return response
+
+    fake_client = SimpleNamespace(responses=SimpleNamespace(create=create))
+    monkeypatch.setattr("ibf.api.impact.OpenAI", lambda **kwargs: fake_client)
+
+    text, cost = _generate_context_openai_web_search(
+        "prompt",
+        model_name="gpt-5.6-luna",
+        api_key="key",
+        name="Otaki",
+    )
+
+    assert text == _valid_synthesis()
+    assert cost == 0.0
+    assert captured["model"] == "gpt-5.6-luna"
+    assert captured["tools"] == [{"type": "web_search"}]
+
+
+def test_openai_context_discards_response_without_search_call(monkeypatch) -> None:
+    response = SimpleNamespace(
+        output_text=_valid_synthesis(),
+        output=[SimpleNamespace(type="message")],
+        usage=None,
+    )
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: response)
+    )
+    monkeypatch.setattr("ibf.api.impact.OpenAI", lambda **kwargs: fake_client)
+
+    text, cost = _generate_context_openai_web_search(
+        "prompt",
+        model_name="gpt-5.6-luna",
+        api_key="key",
+        name="Otaki",
+    )
+
+    assert text == ""
+    assert cost == 0.0
+
+
 def test_hosted_search_regional_prompt_includes_representative_places(monkeypatch) -> None:
     captured = {}
 
@@ -693,14 +743,14 @@ def test_context_cache_provenance_round_trips(tmp_path: Path) -> None:
     assert generated_at == "2026-07-28T08:30:00+12:00"
 
 
-def test_restored_default_context_model_shares_preview_cache_key(
+def test_gemini_default_reuses_legacy_cache_but_luna_does_not(
     tmp_path, monkeypatch
 ) -> None:
     monkeypatch.setattr("ibf.api.impact.CACHE_DIR", tmp_path)
     date = datetime(2026, 7, 26, tzinfo=timezone.utc)
 
-    current = _cache_path("location", "Otaki", 4, "UTC", date_override=date)
-    legacy = _cache_path(
+    default = _cache_path("location", "Otaki", 4, "UTC", date_override=date)
+    legacy_gemini = _cache_path(
         "location",
         "Otaki",
         4,
@@ -708,10 +758,19 @@ def test_restored_default_context_model_shares_preview_cache_key(
         date_override=date,
         context_llm="gemini-3-flash-preview",
     )
+    luna = _cache_path(
+        "location",
+        "Otaki",
+        4,
+        "UTC",
+        date_override=date,
+        context_llm="gpt-5.6-luna",
+    )
 
-    assert "__gemini" not in current.name
-    assert "__gemini" not in legacy.name
-    assert current == legacy
+    assert default == legacy_gemini
+    assert "__gemini" not in default.name
+    assert "__gpt_56_luna" in luna.name
+    assert luna != default
 
 
 def test_brave_failure_can_fall_back_to_explicit_hosted_search_model(monkeypatch, tmp_path) -> None:

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from ibf.llm.costs import get_model_cost
 from ibf.llm.usage import log_gemini_usage_and_cost, log_openai_usage_and_cost
 
 
@@ -38,6 +39,27 @@ def test_direct_provider_uses_updated_estimate_when_cost_is_not_returned() -> No
     )
 
     assert cents == pytest.approx(200.0)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "input_price", "cached_price", "output_price"),
+    [
+        ("gpt-5.6-luna", 0.20, 0.02, 1.20),
+        ("gpt-5.6-terra", 2.00, 0.20, 12.00),
+    ],
+)
+def test_gpt_56_models_use_current_standard_prices(
+    model_name: str,
+    input_price: float,
+    cached_price: float,
+    output_price: float,
+) -> None:
+    entry = get_model_cost(model_name)
+
+    assert entry is not None
+    assert entry.input_per_million == input_price
+    assert entry.cached_input_per_million == cached_price
+    assert entry.output_per_million == output_price
 
 
 def test_gemini_estimate_accounts_for_cached_input_tokens() -> None:

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from ibf.config.models import ForecastConfig
+from ibf.llm.client import _call_openai_compatible
+from ibf.llm.settings import LLMSettings, resolve_llm_settings
+from ibf.pipeline.executor import (
+    _gemini_thinking_level,
+    _log_cost_summary,
+    _reasoning_payload,
+    _record_cost,
+    _reset_cost_tracker,
+)
+
+
+def test_default_llm_is_direct_luna(monkeypatch) -> None:
+    monkeypatch.delenv("IBF_DEFAULT_LLM", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    settings = resolve_llm_settings(ForecastConfig())
+
+    assert settings.model == "gpt-5.6-luna"
+    assert settings.provider == "openai"
+
+
+def test_direct_luna_uses_gpt5_chat_parameters(monkeypatch) -> None:
+    captured = {}
+    response = SimpleNamespace(
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="Forecast text"),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return response
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
+    monkeypatch.setattr("ibf.llm.client.OpenAI", lambda **kwargs: fake_client)
+    settings = LLMSettings(
+        model="gpt-5.6-luna",
+        api_key="test-key",
+        provider="openai",
+    )
+
+    text = _call_openai_compatible(
+        "user",
+        "system",
+        settings,
+        reasoning={"reasoning": {"effort": "high"}},
+    )
+
+    assert text == "Forecast text"
+    assert captured["max_completion_tokens"] == settings.max_tokens
+    assert captured["reasoning_effort"] == "high"
+    assert "max_tokens" not in captured
+    assert "temperature" not in captured
+    assert "extra_body" not in captured
+
+
+def test_enabled_reasoning_defaults_high_but_explicit_values_win() -> None:
+    assert _reasoning_payload(True, None) == {"reasoning": {"effort": "high"}}
+    assert _reasoning_payload(True, "low") == {"reasoning": {"effort": "low"}}
+    assert _reasoning_payload(False, "high") is None
+    assert _gemini_thinking_level(True, None) == "high"
+    assert _gemini_thinking_level(True, "auto") is None
+    assert _gemini_thinking_level(False, "high") == "minimal"
+
+
+def test_cost_summary_logs_two_decimal_places(caplog) -> None:
+    _reset_cost_tracker()
+    _record_cost(
+        "Location",
+        "Test City",
+        context=0.126,
+        forecast=0.234,
+        translation=0.345,
+    )
+
+    with caplog.at_level(logging.INFO, logger="ibf.pipeline.executor"):
+        _log_cost_summary()
+
+    assert "0.13" in caplog.text
+    assert "0.23" in caplog.text
+    assert "0.34" in caplog.text
+    assert "Grand total" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "ibf"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "ibf"
-version = "0.8.4"
+version = "0.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## What changed

- Makes GPT-5.6 Luna the default forecast-writing and translation model, with current Luna and Terra token pricing.
- Allows direct OpenAI GPT models for `llm-search` impact context, using the Responses web-search tool and rejecting responses that did not actually search.
- Keeps `gemini-3-flash-preview` as the default and recommended context model because hosted-search fees can outweigh Luna's lower token rates at normal IBF volumes.
- Keeps `enable_reasoning` as the backward-compatible master switch while adding separate location and area reasoning levels that default to `high`.
- Adds another decimal place to the end-of-run cost table and documents tool-fee limitations.
- Updates examples, README guidance, runtime/citation metadata, and the lock file for IBF 0.8.6.

## Why

Luna and Terra pricing fell substantially, making Luna a strong low-cost default for forecast generation and translation. Context research has different economics: OpenAI web search adds a per-call tool fee plus search-content tokens, while paid Gemini 3 projects currently include a monthly grounding allowance. IBF therefore needs role-specific defaults instead of assuming the cheapest token model is also the cheapest search model.

## User and developer impact

Existing configurations remain valid. Users can continue using the single `enable_reasoning` boolean, optionally set explicit per-output reasoning levels, select direct GPT models for grounded context, and see more precise cost totals. The documented recommended cloud split is Luna for writing/translation and Gemini 3 Flash Preview for context.

## Validation

- `uv run pytest -q` — 129 passed
- `uv run ruff check .` — passed
- `uv lock --check` — passed
- `git diff --check` — passed
- Live Luna run completed successfully from the v0.8.5 base before the release metadata bump