### PR TITLE
Fix forecast contract and compact prose

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ authors:
   - family-names: Gordon
     given-names: Neil
     orcid: "https://orcid.org/0000-0002-7664-9434"
-version: "0.8.10"
-date-released: "2026-08-05"
+version: "0.8.11"
+date-released: "2026-08-06"
 repository-code: "https://github.com/tehoro/ibf"
 url: "https://github.com/tehoro/ibf"
 license: Apache-2.0
@@ -35,6 +35,6 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-7664-9434"
   title: "IBF (Impact-Based Forecast Toolkit): LLM-assisted generation of impact-based weather forecasts"
   year: 2026
-  version: "0.8.10"
+  version: "0.8.11"
   url: "https://github.com/tehoro/ibf"
   license: Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ibf"
-version = "0.8.10"
+version = "0.8.11"
 description = "Unified impact-based forecast CLI and service"
 readme = "README.md"
 authors = [

--- a/src/ibf/__init__.py
+++ b/src/ibf/__init__.py
@@ -4,7 +4,7 @@ Core package for the unified Impact-Based Forecast tooling.
 
 from importlib import metadata as _metadata
 
-_EMBEDDED_VERSION = "0.8.10"
+_EMBEDDED_VERSION = "0.8.11"
 
 
 def _resolve_version() -> str:

--- a/src/ibf/llm/compliance.py
+++ b/src/ibf/llm/compliance.py
@@ -134,6 +134,38 @@ _COMPACT_THOUGH_SNOW_DOWN_RE = re.compile(
     r"(?P<level>\d+(?:\.\d+)?)\s*(?P<unit>metres?|meters?|feet|ft|m)\b",
     re.IGNORECASE,
 )
+_COMPACT_CLEAR_AND_CLEAR_RE = re.compile(
+    r"\bclear(?: skies)?\s+and\s+(?P<modifier>mainly|mostly)\s+clear(?: skies)?\b",
+    re.IGNORECASE,
+)
+_COMPACT_STRENGTHENING_TO_DIRECTION_RE = re.compile(
+    r"\bstrengthening\s+to\s+(?:an?\s+)?"
+    r"(?P<direction>(?:north|south|east|west)(?:-?(?:east|west))?erly)\b",
+    re.IGNORECASE,
+)
+_COMPACT_STANDALONE_TOTAL_RE = re.compile(
+    r"\bGiving\s+(?P<amount>\d+(?:\.\d+)?\s*(?:mm|cm|inches?|in)\b)\s+in\s+total\.\s*",
+    re.IGNORECASE,
+)
+_COMPACT_WIND_CLEARING_RE = re.compile(
+    r"(?P<wind>\b[^.!?]{0,140}\b(?:winds?|northerlies|southerlies|easterlies|westerlies)\b"
+    r"[^.!?]{0,140}?),\s*before\s+clearing\s+(?P<timing>[^.!?]+)(?P<punct>[.!?])",
+    re.IGNORECASE,
+)
+_COMPACT_INLINE_TEMPERATURE_NARRATIVE_RE = re.compile(
+    rf",\s*(?:with\s+)?(?:temperatures?\b|(?:a|the)\s+(?:low|high)\b)"
+    rf"[^.!?]*{_COMPACT_TEMPERATURE_VALUE}[^.!?]*[.!?]",
+    re.IGNORECASE,
+)
+_COMPACT_TEMPERATURE_NARRATIVE_SENTENCE_RE = re.compile(
+    r"(?P<lead>^|[.!?]\s+)(?:(?:temperatures?|the\s+temperature)\b|"
+    rf"(?:a|the)\s+(?:low|high)\b)[^.!?]*{_COMPACT_TEMPERATURE_VALUE}[^.!?]*[.!?]\s*",
+    re.IGNORECASE,
+)
+_COMPACT_PARTIAL_REST_OF_DAY_RE = re.compile(
+    rf"\b(?P<state>{_COMPACT_SKY_STATE})\s+for\s+the\s+rest\s+of\s+the\s+day\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -171,7 +203,7 @@ def postprocess_compact_spot_output(
         body = _COMPACT_WILL_BE_PRESENT_RE.sub("", body)
         body = _normalise_compact_temperature_order(body, partial=partial)
         if not alerts_present:
-            body = _normalise_compact_forecast_wording(body)
+            body = _normalise_compact_forecast_wording(body, partial=partial)
             body = _remove_redundant_compact_timing(body, partial=partial)
             body = _remove_unreportable_compact_gusts(
                 body,
@@ -226,18 +258,95 @@ def _remove_redundant_compact_timing(text: str, *, partial: bool) -> str:
     processed = _COMPACT_STEADY_DAY_RE.sub(r"\g<state>", processed)
     processed = _COMPACT_LIGHT_WINDS_THROUGHOUT_RE.sub(r"\g<state>", processed)
     if partial:
+        processed = _COMPACT_PARTIAL_REST_OF_DAY_RE.sub(r"\g<state>", processed)
         processed = _COMPACT_PARTIAL_REMAINS_CLEAR_RE.sub(r"\g<state>", processed)
         processed = _COMPACT_PARTIAL_STEADY_RE.sub(r"\g<state>", processed)
     return processed
 
 
-def _normalise_compact_forecast_wording(text: str) -> str:
+def _normalise_compact_forecast_wording(text: str, *, partial: bool) -> str:
     """Apply narrow natural-language fixes approved for the compact profile."""
     processed = _COMPACT_CLEAR_WITH_LIGHT_WINDS_RE.sub("Clear with light winds", text)
     processed = _COMPACT_INCLUDING_TOTAL_RE.sub(r"giving \g<amount> in total", processed)
     processed = _COMPACT_SNOW_REACH_AREA_RE.sub(_replace_compact_snow_above, processed)
     processed = _COMPACT_SNOW_MAINLY_SETTLING_RE.sub(_replace_compact_snow_above, processed)
-    return _COMPACT_THOUGH_SNOW_DOWN_RE.sub(_replace_compact_snow_down, processed)
+    processed = _COMPACT_THOUGH_SNOW_DOWN_RE.sub(_replace_compact_snow_down, processed)
+    processed = _COMPACT_CLEAR_AND_CLEAR_RE.sub(_replace_clear_and_clear, processed)
+    processed = _COMPACT_STRENGTHENING_TO_DIRECTION_RE.sub(
+        r"strengthening and turning \g<direction>",
+        processed,
+    )
+    processed = _normalise_wind_clearing(processed)
+    processed = _attach_standalone_precipitation_total(processed)
+    if not partial:
+        processed = _remove_repeated_temperature_narrative(processed)
+    return processed
+
+
+def _replace_clear_and_clear(match: re.Match[str]) -> str:
+    replacement = f"{match.group('modifier').lower()} clear"
+    return replacement.capitalize() if match.group(0)[0].isupper() else replacement
+
+
+def _normalise_wind_clearing(text: str) -> str:
+    """Make a wind-subject clearing clause unambiguous."""
+    rain_present = bool(_RAIN_WORD_RE.search(text))
+
+    def replace(match: re.Match[str]) -> str:
+        ending = f"easing {match.group('timing')}"
+        if rain_present:
+            ending += " as the rain clears"
+        return f"{match.group('wind')}, {ending}{match.group('punct')}"
+
+    return _COMPACT_WIND_CLEARING_RE.sub(replace, text)
+
+
+def _attach_standalone_precipitation_total(text: str) -> str:
+    """Move a detached total back to the nearest preceding precipitation sentence."""
+    total_match = _COMPACT_STANDALONE_TOTAL_RE.search(text)
+    if not total_match:
+        return text
+
+    preceding = text[: total_match.start()]
+    sentences = list(re.finditer(r"(?:\d\.\d|[^.!?])+[.!?]", preceding))
+    precipitation_sentence = next(
+        (
+            sentence
+            for sentence in reversed(sentences)
+            if _RAIN_WORD_RE.search(sentence.group(0)) or _SNOW_WORD_RE.search(sentence.group(0))
+        ),
+        None,
+    )
+    if precipitation_sentence is None:
+        return text
+
+    sentence = precipitation_sentence.group(0).rstrip()
+    attached = f"{sentence[:-1].rstrip()}, giving {total_match.group('amount')} in total."
+    processed = (
+        preceding[: precipitation_sentence.start()]
+        + attached
+        + preceding[precipitation_sentence.end() :]
+        + text[total_match.end() :]
+    )
+    return re.sub(r" {2,}", " ", processed)
+
+
+def _remove_repeated_temperature_narrative(text: str) -> str:
+    """Keep full-day extrema in their final low/high sentence only."""
+    summaries = list(_COMPACT_TEMPERATURE_PAIR_RE.finditer(text))
+    if not summaries:
+        return text
+
+    summary = summaries[-1]
+    preceding = text[: summary.start()]
+    preceding = _COMPACT_INLINE_TEMPERATURE_NARRATIVE_RE.sub(".", preceding)
+
+    def remove_sentence(match: re.Match[str]) -> str:
+        lead = match.group("lead")
+        return "" if not lead else f"{lead.rstrip()} "
+
+    preceding = _COMPACT_TEMPERATURE_NARRATIVE_SENTENCE_RE.sub(remove_sentence, preceding)
+    return preceding + text[summary.start() :]
 
 
 def _replace_compact_snow_above(match: re.Match[str]) -> str:
@@ -345,6 +454,9 @@ def format_spot_output_contract(requirements: Iterable[SpotPeriodRequirement]) -
     lines = [
         "--- MANDATORY OUTPUT CONTRACT ---",
         "Use each supplied period once. Keep the wording concise, but include every fact listed below.",
+        "Only the precipitation amounts listed below are approved for publication. When none is "
+        "listed for a period, describe precipitation qualitatively. Never use an individual "
+        "scenario total.",
     ]
     for period in periods:
         facts: list[str] = []
@@ -354,15 +466,12 @@ def format_spot_output_contract(requirements: Iterable[SpotPeriodRequirement]) -
             facts.append(f"high {period.high}")
         if period.rainfall:
             facts.append(f"rainfall {period.rainfall} (must be stated)")
-        elif period.forbidden_rainfall:
-            facts.append("no approved rainfall amount; do not use an individual scenario total")
-        else:
-            facts.append("no reportable rainfall amount supplied; do not invent one")
         if period.snowfall:
             facts.append(f"snowfall {period.snowfall} (must be stated)")
-        elif period.forbidden_snowfall:
-            facts.append("no approved snowfall amount; do not use an individual scenario total")
-        lines.append(f"- {period.source_label}: " + "; ".join(facts) + ".")
+        if facts:
+            lines.append(f"- {period.source_label}: " + "; ".join(facts) + ".")
+        else:
+            lines.append(f"- {period.source_label}.")
 
     lines.append("Return only the forecast paragraphs.")
     return "\n".join(lines)

--- a/src/ibf/llm/compliance.py
+++ b/src/ibf/llm/compliance.py
@@ -147,6 +147,14 @@ _COMPACT_STANDALONE_TOTAL_RE = re.compile(
     r"\bGiving\s+(?P<amount>\d+(?:\.\d+)?\s*(?:mm|cm|inches?|in)\b)\s+in\s+total\.\s*",
     re.IGNORECASE,
 )
+_COMPACT_TOTAL_AFTER_CLEARING_RE = re.compile(
+    r"(?P<precip>\b[^.!?]{0,160}\b(?:rain|showers?|snow)\b[^.!?]{0,100}?),\s+"
+    r"(?P<transition>(?:clearing|easing|turning)[^.!?]{0,100}?),\s+"
+    r"(?P<amount>with\s+\d+(?:\.\d+)?\s*(?:mm|cm|inches?|in)\s+"
+    r"(?:of\s+(?:rainfall|snowfall)\s+)?expected(?:\s+in\s+total)?)"
+    r"(?P<punct>[.!?])",
+    re.IGNORECASE,
+)
 _COMPACT_WIND_CLEARING_RE = re.compile(
     r"(?P<wind>\b[^.!?]{0,140}\b(?:winds?|northerlies|southerlies|easterlies|westerlies)\b"
     r"[^.!?]{0,140}?),\s*before\s+clearing\s+(?P<timing>[^.!?]+)(?P<punct>[.!?])",
@@ -164,6 +172,65 @@ _COMPACT_TEMPERATURE_NARRATIVE_SENTENCE_RE = re.compile(
 )
 _COMPACT_PARTIAL_REST_OF_DAY_RE = re.compile(
     rf"\b(?P<state>{_COMPACT_SKY_STATE})\s+for\s+the\s+rest\s+of\s+the\s+day\b",
+    re.IGNORECASE,
+)
+_COMPACT_PARTIAL_THIS_AFTERNOON_RE = re.compile(
+    rf"\b(?P<state>{_COMPACT_SKY_STATE})\s+this\s+afternoon\b",
+    re.IGNORECASE,
+)
+_COMPACT_PARTIAL_MOST_OF_EVENING_RE = re.compile(
+    rf"\b(?P<state>{_COMPACT_SKY_STATE})\s+for\s+most\s+of\s+the\s+evening\b",
+    re.IGNORECASE,
+)
+_COMPACT_PARTIAL_AFTER_MIDNIGHT_CLAUSE_RE = re.compile(
+    r",\s*(?:turning|becoming|clearing|changing)[^.!?]{0,80}"
+    r"\b(?:in|during)\s+the\s+early\s+morning\b",
+    re.IGNORECASE,
+)
+_COMPACT_EVENING_TO_EARLY_MORNING_RE = re.compile(
+    r"(?P<evening>\bevening)\s+before\s+(?P<change>clearing|easing|ending)\s+"
+    r"in\s+the\s+early\s+morning\b",
+    re.IGNORECASE,
+)
+_COMPACT_SUNNY_EVENING_RE = re.compile(
+    r"\b(?:(?P<modifier>mostly|mainly)\s+)?sunny"
+    r"(?P<timing>\s+(?:in\s+the\s+)?(?:(?:early|late)\s+)?(?:this\s+)?evening)\b",
+    re.IGNORECASE,
+)
+_COMPACT_CHANGE_RE = re.compile(
+    r"\b(?:becoming|turning|developing|starting|remaining|leading\s+to|followed\s+by)\b",
+    re.IGNORECASE,
+)
+_COMPACT_LATER_CHANGE_RE = re.compile(
+    r"\b(?:before|then|later)\b[^.!?]{0,80}"
+    r"\b(?:easing|clearing|ending|stopping|turning|becoming)\b",
+    re.IGNORECASE,
+)
+_COMPACT_PERSISTENCE_TAIL_RE = re.compile(
+    r",?\s+(?:and\s+)?(?:"
+    r"remaining(?:\s+so|\s+(?:mostly\s+|mainly\s+)?(?:clear|cloudy|overcast))?\s+"
+    r"(?:for\s+)?(?:the\s+)?(?:rest\s+of\s+the\s+day|during\s+the\s+day|"
+    r"(?:much|most)\s+of\s+(?:the\s+)?(?:day|morning|afternoon|evening)|"
+    r"through(?:out)?\s+(?:much\s+of\s+)?(?:the\s+)?(?:day|afternoon|evening)"
+    r"(?:\s+and\s+(?:the\s+)?evening)?)"
+    r"|(?:continuing|lasting)\s+(?:through(?:out)?|into)\s+"
+    r"(?:(?:much|most)\s+of\s+)?"
+    r"(?:the\s+)?(?:day|morning|afternoon|evening)(?:\s+and\s+(?:the\s+)?evening)?"
+    r"|through\s+to\s+the\s+rest\s+of\s+the\s+day"
+    r"|throughout\s+(?:the\s+)?day\s+and\s+(?:the\s+)?evening"
+    r")",
+    re.IGNORECASE,
+)
+_COMPACT_LIGHT_DIRECTIONAL_WIND_RE = re.compile(
+    r"\blight(?:\s+(?:north|south|east|west)(?:-?(?:east|west))?erly)?\s+winds\b",
+    re.IGNORECASE,
+)
+_COMPACT_WINDS_ARE_LIGHT_RE = re.compile(
+    r"\bwinds\s+(?:will\s+be|are|remain)\s+light\b",
+    re.IGNORECASE,
+)
+_COMPACT_SIGNIFICANT_WIND_RE = re.compile(
+    r"\b(?:gust|strong|fresh|gale|severe|storm-force|hurricane-force)\w*\b",
     re.IGNORECASE,
 )
 
@@ -258,10 +325,17 @@ def _remove_redundant_compact_timing(text: str, *, partial: bool) -> str:
     processed = _COMPACT_STEADY_DAY_RE.sub(r"\g<state>", processed)
     processed = _COMPACT_LIGHT_WINDS_THROUGHOUT_RE.sub(r"\g<state>", processed)
     if partial:
+        processed = _COMPACT_PARTIAL_THIS_AFTERNOON_RE.sub(r"\g<state>", processed)
         processed = _COMPACT_PARTIAL_REST_OF_DAY_RE.sub(r"\g<state>", processed)
+        processed = _COMPACT_PARTIAL_MOST_OF_EVENING_RE.sub(r"\g<state>", processed)
         processed = _COMPACT_PARTIAL_REMAINS_CLEAR_RE.sub(r"\g<state>", processed)
         processed = _COMPACT_PARTIAL_STEADY_RE.sub(r"\g<state>", processed)
-    return processed
+    return re.sub(
+        rf"\b(?P<state>{_COMPACT_SKY_STATE}),\s+with light winds\b",
+        r"\g<state> with light winds",
+        processed,
+        flags=re.IGNORECASE,
+    )
 
 
 def _normalise_compact_forecast_wording(text: str, *, partial: bool) -> str:
@@ -278,9 +352,132 @@ def _normalise_compact_forecast_wording(text: str, *, partial: bool) -> str:
     )
     processed = _normalise_wind_clearing(processed)
     processed = _attach_standalone_precipitation_total(processed)
+    processed = _COMPACT_TOTAL_AFTER_CLEARING_RE.sub(
+        r"\g<precip>, \g<amount>, \g<transition>\g<punct>",
+        processed,
+    )
+    processed = _normalise_compact_period_boundary(processed, partial=partial)
+    processed = _COMPACT_SUNNY_EVENING_RE.sub(_replace_sunny_evening, processed)
+    processed = re.sub(
+        r"\bleading\s+to\s+a\s+period\s+of\b",
+        "turning to",
+        processed,
+        flags=re.IGNORECASE,
+    )
+    processed = re.sub(
+        r"\bduring/through\s+the\s+day\b",
+        "during the day",
+        processed,
+        flags=re.IGNORECASE,
+    )
+    processed = _remove_implicit_persistence_tails(processed)
+    processed = _simplify_compact_light_winds(processed)
     if not partial:
         processed = _remove_repeated_temperature_narrative(processed)
     return processed
+
+
+def _replace_sunny_evening(match: re.Match[str]) -> str:
+    """Use night-time sky terminology for compact evening forecasts."""
+    modifier = match.group("modifier")
+    replacement = f"{modifier + ' ' if modifier else ''}clear{match.group('timing')}"
+    return replacement.capitalize() if match.group(0)[0].isupper() else replacement
+
+
+def _normalise_compact_period_boundary(text: str, *, partial: bool) -> str:
+    """Keep compact timing inside the paragraph's supplied calendar period."""
+    if partial:
+        processed = _COMPACT_PARTIAL_AFTER_MIDNIGHT_CLAUSE_RE.sub("", text)
+        processed = re.sub(
+            r"\bby\s+(?:the\s+)?(?:early\s+morning|late\s+(?:night|tonight))\b",
+            "by midnight",
+            processed,
+            flags=re.IGNORECASE,
+        )
+        processed = re.sub(
+            r"\bthrough\s+the\s+night\b",
+            "through the evening",
+            processed,
+            flags=re.IGNORECASE,
+        )
+        processed = re.sub(
+            r"\blate\s+tonight\b",
+            "late this evening",
+            processed,
+            flags=re.IGNORECASE,
+        )
+        return re.sub(r"\btonight\b", "this evening", processed, flags=re.IGNORECASE)
+
+    processed = _COMPACT_EVENING_TO_EARLY_MORNING_RE.sub(
+        r"\g<evening>, then \g<change> late",
+        text,
+    )
+    processed = re.sub(
+        r"\blate\s+(?:in\s+the\s+night|at\s+night|night)\b",
+        "late in the evening",
+        processed,
+        flags=re.IGNORECASE,
+    )
+    processed = re.sub(
+        r"\bovernight\b",
+        "late in the evening",
+        processed,
+        flags=re.IGNORECASE,
+    )
+    return re.sub(r"\btonight\b", "in the evening", processed, flags=re.IGNORECASE)
+
+
+def _remove_implicit_persistence_tails(text: str) -> str:
+    """Remove end-of-period persistence after an onset or change is already timed."""
+
+    def simplify_sentence(match: re.Match[str]) -> str:
+        sentence = match.group(0)
+        if not _COMPACT_CHANGE_RE.search(sentence):
+            return sentence
+
+        def remove_tail(tail: re.Match[str]) -> str:
+            if _COMPACT_LATER_CHANGE_RE.search(sentence[tail.end() :]):
+                return tail.group(0)
+            return ""
+
+        simplified = _COMPACT_PERSISTENCE_TAIL_RE.sub(remove_tail, sentence)
+        simplified = re.sub(r"\s+,", ",", simplified)
+        return re.sub(r",\s*,", ",", simplified)
+
+    return re.sub(r"(?:\d\.\d|[^.!?])+[.!?]", simplify_sentence, text)
+
+
+def _simplify_compact_light_winds(text: str) -> str:
+    """Suppress minor directions and shifts when the prose itself calls winds light."""
+
+    def simplify_sentence(match: re.Match[str]) -> str:
+        sentence = match.group(0)
+        if _COMPACT_SIGNIFICANT_WIND_RE.search(sentence):
+            return sentence
+        stripped = sentence.lstrip()
+        leading = sentence[: len(sentence) - len(stripped)]
+        if _COMPACT_LIGHT_DIRECTIONAL_WIND_RE.match(stripped) or _COMPACT_WINDS_ARE_LIGHT_RE.match(
+            stripped
+        ):
+            return f"{leading}Light winds."
+
+        inline = re.search(
+            r",?\s+with\s+light(?:\s+(?:north|south|east|west)"
+            r"(?:-?(?:east|west))?erly)?\s+winds\b[^.!?]*",
+            sentence,
+            re.IGNORECASE,
+        )
+        if inline:
+            simplified = sentence[: inline.start()] + ", with light winds" + sentence[inline.end() :]
+            return re.sub(
+                r"\b(clear|mainly clear|mostly clear),\s+with light winds\b",
+                r"\1 with light winds",
+                simplified,
+                flags=re.IGNORECASE,
+            )
+        return sentence
+
+    return re.sub(r"(?:\d\.\d|[^.!?])+[.!?]", simplify_sentence, text)
 
 
 def _replace_clear_and_clear(match: re.Match[str]) -> str:

--- a/src/ibf/llm/prompts.py
+++ b/src/ibf/llm/prompts.py
@@ -401,8 +401,10 @@ Write a real forecast, not a list of weather fields or a compressed telegram. Us
 - ccNN is total cloud cover: use it only as a broad sky cue. Ignore short-lived cloud flicker, especially before dawn, and never infer fog or low cloud from ccNN alone.
 - Use no more than two broad sky descriptions in a paragraph, in time order. Do not announce a change between similar states such as mostly clear and partly cloudy, or cloudy and overcast, unless it is sustained and important to the day's story.
 - Describe a spell of precipitation once, with its prevailing intensity and useful broad timing. Do not stack conflicting intensities. Never pair rain or snow with a clear or sunny sky in the same clause.
+- Treat rain and showers as one evolving spell. Write "rain becoming showery in the afternoon", never "rain throughout the day with showers in the afternoon".
 - Work required rain or snow amounts and any reportable snow level naturally into the weather sentence.
 - Link a rain total naturally to the precipitation sentence, for example "giving X mm in total" or "with X mm expected". Never leave the amount as a separate sentence or place it after the wind sentence. Never write "including a total of X".
+- If precipitation clears later, keep its amount beside the precipitation clause: write "Rain in the morning, with X mm expected, clearing in the afternoon", not "Rain in the morning, clearing in the afternoon, with X mm expected".
 - Use connecting words such as "with", "as", "turning to", "clearing", "followed by" and "later" where they help the forecast flow.
 - For a steady clear period with light winds, simply say "Clear with light winds."
 

--- a/src/ibf/llm/prompts.py
+++ b/src/ibf/llm/prompts.py
@@ -393,7 +393,7 @@ Write a real forecast, not a list of weather fields or a compressed telegram. Us
 # PERIOD STRUCTURE
 - Write one paragraph for every supplied period, in the supplied order. Begin it exactly as "**[supplied label]:**" and continue on the same line. Never add, merge or omit a period.
 - Cover only the supplied hours. Keep a partial label such as "Rest of Today". For that current partial period, describe the temperature trend, or put the remaining-period high before the low if both are stated.
-- Let each paragraph breathe. Usually give the weather first, then the wind. For a full midnight-to-midnight day, finish with "A low of [low] and a high of [high]", repeating {temperature_symbol} on both values. Join related facts when that sounds more natural; do not force every category into its own clipped sentence.
+- Let each paragraph breathe. Usually give the weather first, then the wind. For a full midnight-to-midnight day, finish with "A low of [low] and a high of [high]", repeating {temperature_symbol} on both values. State those daily extremes only in that final sentence; do not repeat them in the weather narrative. Join related facts when that sounds more natural; do not force every category into its own clipped sentence.
 - Output only forecast paragraphs: no bullets, analysis, greeting, sign-off or general advice.
 
 # WEATHER
@@ -402,7 +402,7 @@ Write a real forecast, not a list of weather fields or a compressed telegram. Us
 - Use no more than two broad sky descriptions in a paragraph, in time order. Do not announce a change between similar states such as mostly clear and partly cloudy, or cloudy and overcast, unless it is sustained and important to the day's story.
 - Describe a spell of precipitation once, with its prevailing intensity and useful broad timing. Do not stack conflicting intensities. Never pair rain or snow with a clear or sunny sky in the same clause.
 - Work required rain or snow amounts and any reportable snow level naturally into the weather sentence.
-- Link a rain total naturally, for example "giving X mm in total" or "with X mm expected". Never write "including a total of X".
+- Link a rain total naturally to the precipitation sentence, for example "giving X mm in total" or "with X mm expected". Never leave the amount as a separate sentence or place it after the wind sentence. Never write "including a total of X".
 - Use connecting words such as "with", "as", "turning to", "clearing", "followed by" and "later" where they help the forecast flow.
 - For a steady clear period with light winds, simply say "Clear with light winds."
 
@@ -411,7 +411,7 @@ Write a real forecast, not a list of weather fields or a compressed telegram. Us
 - If sustained speeds remain below {light_wind_speed} {wind_unit} and no gust exceeds {gust_reporting_floor} {wind_unit}, simply say "Light winds." Omit directions, numbers and minor shifts.
 - Otherwise describe the prevailing direction and general wind strength without reciting routine speeds. Mention a gust only when it exceeds {gust_reporting_floor} {wind_unit}, and then give the maximum once without making it the focus of the paragraph.
 - Mention no more than two directions, and a second only for a genuine shift lasting several hours. Keep the directions in chronological order and give the shift useful broad timing.
-- Use a natural verb for a real change, such as strengthening, easing, turning or dying away. Never pad the prose with "will be present", "will persist" or "dominate".
+- Use a natural verb for a real change, such as strengthening, easing, turning or dying away. Winds ease rather than clear. If both strength and direction change, say "strengthening and turning northwesterly", not "strengthening to a northwesterly". Never pad the prose with "will be present", "will persist" or "dominate".
 
 # AMOUNTS AND SNOW LEVELS
 - State a rain or snow amount only when the factual contract supplies it, and use that amount exactly. Never invent or recalculate one.

--- a/src/ibf/pipeline/executor.py
+++ b/src/ibf/pipeline/executor.py
@@ -82,6 +82,18 @@ _DAY_HEADER_RE = re.compile(
 )
 _HOURLY_DATA_LINE_RE = re.compile(r"^(?:midnight|noon|\d{1,2}(?:am|pm))\b", re.IGNORECASE)
 _HOURLY_GUST_RE = re.compile(r"\s+gust\s+(\d+(?:\.\d+)?)\b", re.IGNORECASE)
+_HOURLY_SKY_RE = re.compile(
+    r"\s+(?:clear sky|mainly clear|partly cloudy|cloudy|overcast)\s+cc\d+\b",
+    re.IGNORECASE,
+)
+_COMPACT_SKY_ONLY_WEATHER = {
+    "clear",
+    "clear sky",
+    "mainly clear",
+    "partly cloudy",
+    "cloudy",
+    "overcast",
+}
 
 
 @dataclass
@@ -775,6 +787,11 @@ def _generate_location_text_with_adaptive_thinning(
 
     for attempt_index, member_limit in enumerate(member_limits):
         formatted_dataset = payload.formatted_dataset
+        if use_compact_profile and not payload.alerts:
+            formatted_dataset = _prepare_compact_short_period_sky_data(
+                formatted_dataset,
+                payload.dataset,
+            )
         if gust_reporting_floor is not None:
             formatted_dataset = _filter_unreportable_compact_gusts(
                 formatted_dataset,
@@ -1115,6 +1132,71 @@ def _filter_unreportable_compact_gusts(
             )
         filtered_lines.append(line)
     return "\n".join(filtered_lines)
+
+
+def _prepare_compact_short_period_sky_data(
+    formatted_dataset: str,
+    dataset: List[dict],
+) -> str:
+    """Replace dry short-period sky flicker with one broad compact-only cue."""
+    if not dataset:
+        return formatted_dataset
+    first_day = dataset[0]
+    label = str(first_day.get("dayofweek", "")).upper()
+    if not any(key in label for key in ("REST OF", "THIS EVENING", "THIS AFTERNOON")):
+        return formatted_dataset
+
+    hours = first_day.get("hours", [])
+    if not isinstance(hours, list) or not 2 <= len(hours) <= 9:
+        return formatted_dataset
+
+    cloud_cover: List[float] = []
+    for hour in hours:
+        members = hour.get("ensemble_members", {}) if isinstance(hour, dict) else {}
+        if not isinstance(members, dict) or len(members) != 1:
+            return formatted_dataset
+        member = next(iter(members.values()))
+        if not isinstance(member, dict):
+            return formatted_dataset
+        weather = str(member.get("weather", "")).strip().lower()
+        cloud = member.get("cloud_cover")
+        precipitation = member.get("precipitation", 0.0)
+        snowfall = member.get("snowfall", 0.0)
+        if (
+            weather not in _COMPACT_SKY_ONLY_WEATHER
+            or not isinstance(cloud, (int, float))
+            or not isinstance(precipitation, (int, float))
+            or not isinstance(snowfall, (int, float))
+            or precipitation > 0
+            or snowfall > 0
+        ):
+            return formatted_dataset
+        cloud_cover.append(float(cloud))
+
+    edge_size = min(2, len(cloud_cover))
+    starts_cloudy = sum(cloud_cover[:edge_size]) / edge_size >= 60
+    ends_cloudy = sum(cloud_cover[-edge_size:]) / edge_size >= 60
+    if starts_cloudy == ends_cloudy:
+        broad_sky = "Mostly cloudy." if starts_cloudy else "Mainly clear."
+    elif starts_cloudy:
+        broad_sky = "Mostly cloudy at first, clearing later."
+    else:
+        broad_sky = "Mainly clear at first, becoming mostly cloudy later."
+
+    lines = formatted_dataset.splitlines()
+    date_index = next((index for index, line in enumerate(lines) if line.startswith("Date:")), None)
+    if date_index is None:
+        return formatted_dataset
+    lines.insert(
+        date_index + 1,
+        "First-period broad sky (use instead of hourly sky changes): " + broad_sky,
+    )
+    for index in range(date_index + 2, len(lines)):
+        if lines[index].startswith("Date:"):
+            break
+        if _HOURLY_DATA_LINE_RE.match(lines[index]):
+            lines[index] = _HOURLY_SKY_RE.sub("", lines[index])
+    return "\n".join(lines)
 
 
 def _format_location_payload(

--- a/tests/test_forecast_compliance.py
+++ b/tests/test_forecast_compliance.py
@@ -74,7 +74,9 @@ def test_deterministic_contract_requires_supplied_total_and_temperatures() -> No
     contract = format_spot_output_contract(requirements)
 
     assert "TUESDAY 4 AUGUST: low 7°C; high 10°C; rainfall 2 mm (must be stated)" in contract
-    assert "MONDAY 3 AUGUST: low 10°C; high 15°C; no reportable rainfall amount supplied" in contract
+    assert "MONDAY 3 AUGUST: low 10°C; high 15°C." in contract
+    assert "describe precipitation qualitatively" in contract
+    assert "no reportable rainfall amount supplied" not in contract
 
     forecast = """**Monday, 3 August:** Clear. Northerlies 20 km/h. The high will be 15°C and the low will be 10°C.
 
@@ -114,7 +116,8 @@ def test_contract_suppresses_sub_reportable_rainfall() -> None:
 
     assert requirements[0].rainfall is None
     assert "rainfall 0.5 mm" not in contract
-    assert "no reportable rainfall amount supplied" in contract
+    assert "TUESDAY 4 AUGUST: low 7°C; high 10°C." in contract
+    assert "no reportable rainfall amount supplied" not in contract
 
 
 def test_partial_period_contract_does_not_force_full_day_temperatures() -> None:
@@ -216,7 +219,8 @@ def test_ensemble_contract_rejects_unapproved_scenario_total() -> None:
     contract = format_spot_output_contract(requirements)
 
     assert requirements[0].forbidden_rainfall == ("7 mm",)
-    assert "no approved rainfall amount; do not use an individual scenario total" in contract
+    assert "Never use an individual scenario total" in contract
+    assert "no approved rainfall amount" not in contract
 
     forecast = (
         "**Wednesday, 5 August:** There is a 40% chance of rain, potentially bringing 7 mm. "
@@ -526,6 +530,34 @@ def test_compact_output_postprocessing_normalises_final_wording_tweaks() -> None
     assert "Snow above about 700 m." in processed
     assert "including a total" not in processed
     assert "mainly settling" not in processed
+
+
+def test_compact_output_postprocessing_normalises_reported_prose_defects() -> None:
+    forecast = """**THIS AFTERNOON AND EVENING, THURSDAY 6 AUGUST:** Clear and mainly clear for the rest of the day, with light winds turning easterly later. A high of 10°C and a low of 3°C.
+
+**FRIDAY 7 AUGUST:** Clear skies, with temperatures rising to a high of 12°C before falling away in the evening. Light winds. A low of 2°C and a high of 12°C.
+
+**SATURDAY 8 AUGUST:** Rain developing in the morning. Easterly winds. Giving 56 mm in total. A low of 7°C and a high of 11°C.
+
+**SUNDAY 9 AUGUST:** Moderate rain and thunderstorms. Strong northeasterly winds will gust to 80 km/h during the afternoon, before clearing in the evening. Northerly winds, strengthening to a north-easterly later. A low of 8°C and a high of 13°C.
+
+**MONDAY 10 AUGUST:** A high chance of rain. Temperatures rise to 14°C in the afternoon. Light winds. A low of 6°C and a high of 14°C."""
+
+    processed = postprocess_compact_spot_output(
+        forecast,
+        gust_reporting_floor=50,
+    )
+
+    assert "Mainly clear, with light winds turning easterly later." in processed
+    assert "Clear skies. Light winds. A low of 2°C and a high of 12°C." in processed
+    assert "temperatures rising to a high" not in processed
+    assert "Rain developing in the morning, giving 56 mm in total. Easterly winds." in processed
+    assert "Giving 56 mm" not in processed
+    assert "easing in the evening as the rain clears" in processed
+    assert "strengthening and turning north-easterly later" in processed
+    assert "before clearing" not in processed
+    assert "strengthening to" not in processed
+    assert "A high chance of rain. Light winds. A low of 6°C and a high of 14°C." in processed
 
 
 def test_compact_output_postprocessing_removes_snow_may_reach_area_wording() -> None:

--- a/tests/test_forecast_compliance.py
+++ b/tests/test_forecast_compliance.py
@@ -435,6 +435,99 @@ Date: WEDNESDAY 5 AUGUST
     assert "2pm 9° Partly cloudy S 30 gust 60" in filtered
 
 
+def test_compact_short_dry_period_uses_one_broad_sky_cue() -> None:
+    cloud_values = [34, 79, 81, 71, 49, 20, 1]
+    weather_values = [
+        "Mainly clear",
+        "Partly cloudy",
+        "Overcast",
+        "Partly cloudy",
+        "Mainly clear",
+        "Mainly clear",
+        "Clear sky",
+    ]
+    hours = [
+        {
+            "hour": f"{hour}:00",
+            "ensemble_members": {
+                "member00": {
+                    "weather": weather,
+                    "cloud_cover": cloud,
+                    "precipitation": 0.0,
+                    "snowfall": 0.0,
+                }
+            },
+        }
+        for hour, weather, cloud in zip(
+            range(17, 24),
+            weather_values,
+            cloud_values,
+            strict=True,
+        )
+    ]
+    dataset = [{"dayofweek": "Rest of Today, Thursday", "hours": hours}]
+    formatted = """Date: REST OF TODAY, THURSDAY 6 AUGUST
+
+5pm 11° Mainly clear cc34 SE 10
+6pm 10° Partly cloudy cc79 S 10
+7pm 9° Overcast cc81 S 10
+8pm 8° Partly cloudy cc71 S 10
+9pm 7° Mainly clear cc49 SW 10
+10pm 6° Mainly clear cc20 SW 10
+11pm 4° Clear sky cc1 SW 10
+
+Date: FRIDAY 7 AUGUST
+midnight 3° Clear sky cc2 SW 10
+"""
+
+    prepared = executor._prepare_compact_short_period_sky_data(formatted, dataset)
+
+    assert "First-period broad sky (use instead of hourly sky changes): Mainly clear." in prepared
+    first_period, second_period = prepared.split("Date: FRIDAY 7 AUGUST")
+    assert "Partly cloudy" not in first_period
+    assert "Overcast" not in first_period
+    assert "cc" not in first_period
+    assert "midnight 3° Clear sky cc2" in second_period
+
+
+def test_compact_short_period_sky_cue_preserves_wet_or_full_day_data() -> None:
+    wet_dataset = [
+        {
+            "dayofweek": "This Evening, Thursday",
+            "hours": [
+                {
+                    "hour": "18:00",
+                    "ensemble_members": {
+                        "member00": {
+                            "weather": "Light rain",
+                            "cloud_cover": 90,
+                            "precipitation": 0.2,
+                            "snowfall": 0.0,
+                        }
+                    },
+                },
+                {
+                    "hour": "19:00",
+                    "ensemble_members": {
+                        "member00": {
+                            "weather": "Overcast",
+                            "cloud_cover": 90,
+                            "precipitation": 0.0,
+                            "snowfall": 0.0,
+                        }
+                    },
+                },
+            ],
+        }
+    ]
+    formatted = "Date: THIS EVENING, THURSDAY 6 AUGUST\n6pm 10° Light rain cc90 0.2 mm/h"
+
+    assert executor._prepare_compact_short_period_sky_data(formatted, wet_dataset) == formatted
+
+    wet_dataset[0]["dayofweek"] = "Friday"
+    assert executor._prepare_compact_short_period_sky_data(formatted, wet_dataset) == formatted
+
+
 def test_compact_output_postprocessing_enforces_objective_period_rules() -> None:
     forecast = """**THIS AFTERNOON AND EVENING, TUESDAY 4 AUGUST:** Light rain this afternoon. Southwesterlies, gusting to 60 km/h. A low of 3°C and a high of 5°C.
 
@@ -486,7 +579,7 @@ def test_compact_output_postprocessing_removes_redundant_steady_timing() -> None
     )
 
     assert "Mainly clear to clear skies. Southerly winds." in processed
-    assert "Clear skies, with light winds." in processed
+    assert "Clear skies with light winds." in processed
     assert "Clear skies at first, becoming overcast from late morning." in processed
     assert "Northerly winds." in processed
     assert "Mostly clear to partly cloudy at first, becoming overcast from late morning." in processed
@@ -548,7 +641,7 @@ def test_compact_output_postprocessing_normalises_reported_prose_defects() -> No
         gust_reporting_floor=50,
     )
 
-    assert "Mainly clear, with light winds turning easterly later." in processed
+    assert "Mainly clear with light winds." in processed
     assert "Clear skies. Light winds. A low of 2°C and a high of 12°C." in processed
     assert "temperatures rising to a high" not in processed
     assert "Rain developing in the morning, giving 56 mm in total. Easterly winds." in processed
@@ -590,8 +683,76 @@ def test_compact_output_postprocessing_removes_will_be_present_only() -> None:
 
     assert "will be present" not in processed
     assert "Southwesterly winds, turning to southerlies later." in processed
-    assert "Light easterly winds, turning to northwesterlies" in processed
+    assert "Light winds." in processed
     assert "Easterly winds in the morning, turning to northwesterlies and then northerlies" in processed
+
+
+def test_compact_output_postprocessing_removes_implicit_persistence() -> None:
+    forecast = """**FRIDAY 7 AUGUST:** Mainly clear at first, becoming overcast from the morning and remaining so for the rest of the day. Light winds, turning westerly later. A low of 0°C and a high of 11°C.
+
+**SATURDAY 8 AUGUST:** Overcast with light rain developing in the early morning, leading to a period of moderate rain showers throughout the day and evening, giving 15 mm. Winds remain light, becoming easterly later. A low of 6°C and a high of 13°C.
+
+**SUNDAY 9 AUGUST:** Rain developing in the morning and continuing through the afternoon before easing in the evening, giving 12 mm. A low of 7°C and a high of 12°C."""
+
+    processed = postprocess_compact_spot_output(
+        forecast,
+        gust_reporting_floor=50,
+    )
+
+    assert "Mainly clear at first, becoming overcast from the morning." in processed
+    assert "turning to moderate rain showers, giving 15 mm" in processed
+    assert "Light winds." in processed
+    assert "remaining so" not in processed
+    assert "throughout the day and evening" not in processed
+    assert "continuing through the afternoon before easing in the evening" in processed
+
+
+def test_compact_output_postprocessing_normalises_latest_observed_wording() -> None:
+    forecast = """**SATURDAY 8 AUGUST:** Mainly clear early on, turning overcast from late morning and remaining so for much of the day. A low of 4°C and a high of 12°C.
+
+**SUNDAY 9 AUGUST:** Light rain developing in the early hours and continuing through most of the day, giving 6 mm in total. A low of 9°C and a high of 14°C.
+
+**MONDAY 10 AUGUST:** Rain during the day, giving 8 mm in total, before clearing to a mostly sunny evening. A low of 11°C and a high of 15°C.
+
+**TUESDAY 11 AUGUST:** Mostly cloudy with early clear spells, remaining overcast for the rest of the day. A low of 8°C and a high of 14°C.
+
+**WEDNESDAY 12 AUGUST:** Moderate rain showers in the early morning, clearing to a mostly sunny afternoon, with 4 mm expected. Light winds. A low of 5°C and a high of 13°C."""
+
+    processed = postprocess_compact_spot_output(
+        forecast,
+        gust_reporting_floor=50,
+    )
+
+    assert "turning overcast from late morning." in processed
+    assert "Light rain developing in the early hours, giving 6 mm in total." in processed
+    assert "clearing to a mostly clear evening" in processed
+    assert "Mostly cloudy with early clear spells." in processed
+    assert (
+        "Moderate rain showers in the early morning, with 4 mm expected, "
+        "clearing to a mostly sunny afternoon."
+    ) in processed
+    assert "remaining so" not in processed
+    assert "continuing through most of the day" not in processed
+    assert "sunny evening" not in processed
+
+
+def test_compact_output_postprocessing_keeps_timing_inside_period() -> None:
+    forecast = """**THIS EVENING, THURSDAY 6 AUGUST:** Cloudy, clearing late tonight. Temperatures fall to 4°C by early morning. Light rain through the night.
+
+**FRIDAY 7 AUGUST:** Cloudy in the evening before clearing in the early morning. Light rain returning overnight. A low of 4°C and a high of 12°C."""
+
+    processed = postprocess_compact_spot_output(
+        forecast,
+        gust_reporting_floor=50,
+    )
+
+    assert "clearing late this evening" in processed
+    assert "by midnight" in processed
+    assert "through the evening" in processed
+    assert "Cloudy in the evening, then clearing late." in processed
+    assert "Light rain returning late in the evening." in processed
+    assert "early morning" not in processed
+    assert "overnight" not in processed
 
 
 def test_location_generation_fails_closed_after_bad_correction(monkeypatch) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -160,11 +160,14 @@ def test_compact_spot_prompt_is_generalized_and_unit_aware(
     assert "The period heading already supplies the overall timeframe" in prompt
     assert "Once a change occurs and then persists, state when it begins" in prompt
     assert "Retain duration wording when prolonged precipitation" in prompt
+    assert 'Write "rain becoming showery in the afternoon"' in prompt
+    assert 'never "rain throughout the day with showers in the afternoon"' in prompt
     assert "ACTIVE ALERTS" in prompt
     assert '"snow down to about X m"' in prompt
     assert "location-relative relevance filter" in prompt
     assert 'say "snow above about X m"' in prompt
     assert 'Never write "including a total of X"' in prompt
+    assert 'with X mm expected, clearing in the afternoon' in prompt
     assert 'say "Clear with light winds."' in prompt
     assert "1000 metres" not in prompt
     assert '"will be present", "will persist" or "dominate"' in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "ibf"
-version = "0.8.10"
+version = "0.8.11"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## What changed

- stop presenting absent precipitation amounts as mandatory per-period facts
- keep the no-invention and no-scenario-total safeguard as a single global generation constraint
- tighten the compact prompt around repeated temperature extrema, rain-total placement, and wind changes
- deterministically repair the reported compact phrases without changing standard-profile prose

## Why

The shared output contract told both cloud and compact models to include every listed fact, while listing “no reportable rainfall amount supplied” as a fact. A Halifax cloud forecast therefore exposed that internal instruction to readers. The latest Gemma compact run also showed several bounded grammar defects: repeated extrema, detached rain totals after wind sentences, wind appearing to clear, “strengthening to” a direction, and duplicated clear-sky synonyms.

## Impact

Cloud forecasts now omit unavailable rainfall quantities silently while continuing to reject individual ensemble-scenario totals. Compact forecasts receive small prompt clarifications and narrow post-processing for the observed defects. Official-alert paragraphs continue to bypass stylistic rewriting.

## Validation

- `uv run pytest -q` — 179 passed
- `uv run ruff check .`
- `git diff --check`
- `uv lock --check`
- `uv run ibf --version` — 0.8.10